### PR TITLE
Explain options for installing BST

### DIFF
--- a/_materials/BufferStockTheory.md
+++ b/_materials/BufferStockTheory.md
@@ -18,3 +18,15 @@ github_path: Code/Python/BufferStockTheory.ipynb
 Theoretical Foundations of Buffer Stock Saving
 
 For a consumption/saving problem with transitory and permanent shocks and unbounded (CRRA) utility, this paper derives conditions under which a nondegenerate solution exists, and under which a target wealth ratio exists; all results are paired with illustrative numerical solutions.
+
+### Options for Executing This Notebook
+
+1. [View (noninteractively)](https://github.com/llorracc/BufferStockTheory/blob/master/Code/Python/BufferStockTheory.ipynb) on GitHub (warning: sometimes GitHub does not render Jupyter notebooks)
+1. [Launch Online Interactive Version](https://econ-ark.org/BufferStockTheory/launch) (warning: takes a couple of minutes)
+1. Install [econ-ark](http://github.com/econ-ark) on your computer ([QUICK START GUIDE](https://github.com/econ-ark/HARK/blob/master/README.md)) then follow these instructions:
+   1. At a command line, change the working directory to the one where you want to install
+       * On MacOS/unix, if you install in the `/tmp` directory, the installation will disappear after a reboot:
+       * `cd /tmp`
+   1. `git clone https://github.com/econ-ark/REMARK --recursive`
+   1. `cd REMARK/REMARKs/BufferStockTheory`
+   1. `jupyter notebook BufferStockTheory.ipynb`


### PR DESCRIPTION
I think the info on the materials page should contain explicit instructions for how people can download the material in question and execute it locally on their own computer.  

As a prototype, I've added such instructions for the BufferStockTheory notebook

