### PR TITLE
Add check for query string dashboard, launch

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -29,12 +29,6 @@
         <meta property="og:image" content="https://econ-ark.org/assets/img/econ-ark-logo.png" />
         <meta property="og:description" content="{{ site.description }}" />
         <meta property="og:site_name" content="{{ site.title }}" />
-        
-        <script type="text/javascript">
-        if (window.location.href.indexOf("%23dashboard") > -1) {
-          window.location.hash = 'dashboard';
-        }
-        </script>
 
         <script data-search-pseudo-elements defer src="https://use.fontawesome.com/releases/v5.6.3/js/solid.js" integrity="sha384-F4BRNf3onawQt7LDHDJm/hwm3wBtbLIfGk1VSB/3nn3E+7Rox1YpYcKJMsmHBJIl" crossorigin="anonymous"></script>
         <script data-search-pseudo-elements defer src="https://use.fontawesome.com/releases/v5.6.3/js/brands.js" integrity="sha384-VLgz+MgaFCnsFLiBwE3ItNouuqbWV2ZnIqfsA6QRHksEAQfgbcoaQ4PP0ZeS0zS5" crossorigin="anonymous"></script>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -112,6 +112,16 @@ window.addEventListener(
 checkForLaunch();
 checkForLaunchDashboard();
 
+// Check for query string, launch notbooks accordingly
+var urlParams = new URLSearchParams(window.location.search);
+if ( urlParams.has('dashboard') ) {
+  var href = document.getElementsByClassName('dashboard-link')[0].href;
+  window.location = href;
+} else if ( urlParams.has('launch') ) {
+  var href = document.getElementsByClassName('launch-link')[0].href;
+  window.location = href;  
+}
+
 // Show/Hide Notebook launching help
 $('.how-to-toggle').click(function () {
   $(this).siblings('.how-to-copy').slideToggle();


### PR DESCRIPTION
Material pages will now also accept query string checks for launching dashboard and notebooks using the format:
"https://econ-ark.org/materials/pandemic?launch" and "https://econ-ark.org/materials/pandemic?dashboard"