### PR TITLE
Rename Carroll_1997_QJE to BufferStock-LifeCycle

### DIFF
--- a/_materials/BufferStock-LifeCycle.md
+++ b/_materials/BufferStock-LifeCycle.md
@@ -14,19 +14,19 @@ authors: # required
     family-names: Son
     given-names: "Jeongwon (John)"
 # REMARK fields
-github_repo_url: https://github.com/econ-ark/Carroll_1997_QJE # required 
+github_repo_url: https://github.com/econ-ark/BufferStock-LifeCycle # required 
 commit: # Git commit number that the REMARK will always use; required for "frozen" remarks, optional for "draft" remarks
-remark-name: Carroll_1997_QJE # required 
+remark-name: BufferStock-LifeCycle # required 
 title-original-paper: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis # optional 
 notebooks: # path to any notebooks within the repo - optional
   - 
-    Carroll_1997_QJE.ipynb
+    BufferStock-LifeCycle.ipynb
 dashboards: # path to any dahsboards within the repo - optional
 identifiers-paper: # required for Replications; optional for Reproductions
 date-published-original-paper: # required for Replications; optional for Reproductions
 ---
 
-# Carroll_1997_QJE
+# BufferStock-LifeCycle
 
 This is a replication of Carroll (1997), Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis.
 

--- a/_materials/EndogenousRetirement.md
+++ b/_materials/EndogenousRetirement.md
@@ -1,6 +1,7 @@
 ---
 tags:
   - REMARK
+  - Reproduction
 location_url: https://github.com/econ-ark/EndogenousRetirement
 name: EndogenousRetirement
 summary: ''


### PR DESCRIPTION
I've changed the name of the Carroll_1997_QJE repo at econ-ark to BufferStock-LifeCycle.  This PR changes the references to that repo in econ-ark.org.  Does anything else need to be done beyond editing the name of the link and the metadata?  And, I can never remember what needs to be done to trigger a rebuild ...
