### PR TITLE
ENH: add ability to build site locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ _site
 .DS_Store
 really-simple*.gem
 Gemfile.lock
+vendor
+.bundle

--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,5 @@ source 'https://rubygems.org'
 
 gem 'jekyll-seo-tag'
 gem 'github-pages', group: :jekyll_plugins
+gem 'webrick' # needed to build locally
+

--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ https://econ-ark.org/materials/distributionofwealthmpc
 
 - Updated SolvingMicroDSOPs.md to point to llorracc/SolvingMicroDSOPS/SolvingMicroDSOPS.ipynb
 
+
+## Local Build Instructions
+
+1. Install Ruby 3.0.4
+2. Run the following commands:
+```
+gem install bundler  # installs bundler gem
+git clone ...        # clone repo
+cd path/to/repo      # navigate to repo top level
+bundle config set --local path 'vendor/bundle'  # set bundler output directory
+bundle install       # bundle your jekyll application
+bundle exec jekyll serve  # begin serving your site locally
+```
+


### PR DESCRIPTION
Adds instructions to build the site for local testing.

Since this page is built via Jekyll, you will need a local ruby install which I've left to the user to do (though we can probably achieve this cross platform via an anaconda environment).

Instructions are in the README file:

1. Install Ruby 3.0.4
2. Run the following commands:
```
gem install bundler  # installs bundler gem
git clone ...        # clone repo
cd path/to/repo      # navigate to repo top level
bundle config set --local path 'vendor/bundle'  # set bundler output directory
bundle install       # bundle your jekyll application
bundle exec jekyll serve  # begin serving your site locally
```