### PR TITLE
ENH: Case Insensitive Redirects

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,3 +41,9 @@ defaults:
       type: 'team'
     values:
       order: 99
+
+plugins:
+  - jekyll-redirect-from
+
+whitelist:
+  - jekyll-redirect-from

--- a/_materials/Aiyagari.md
+++ b/_materials/Aiyagari.md
@@ -1,42 +1,32 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-authors: # required
-  -
-    family-names: "Huang"
-    given-names: "Zixuan" 
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: AiyagariIdiosyncratic # required
-abstract: Aiyagari (1994) Replication # optional
-
-# REMARK required fields
-remark-version: 1.0 # required - specify version of REMARK standard used
-reference: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Krusell"
-        given-names: "Per"
-        # orcid: https://orcid.org/XXXX-XXXX-XXXX-XXXX
-      -
-        family-names: "Smith, Jr."
-        given-names: "Anthony A."
-        # orcid: https://orcid.org/XXXX-XXXX-XXXX-XXXX
-    title: "Income and Wealth Heterogeneity in the Macroeconomy"
-    doi: https://doi.org/10.1086/250034
-    date: 1998
-    publisher: Journal of political Economy
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/KrusellSmith # required 	
-remark-name: KrusellSmith # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/KrusellSmith.ipynb
-
-tags: # Use the relavent tag
-  - REMARK
-  - Notebook
+cff-version: 1.1.0
+authors:
+- family-names: Huang
+  given-names: Zixuan
+title: AiyagariIdiosyncratic
+abstract: Aiyagari (1994) Replication
+remark-version: 1.0
+reference:
+- type: article
+  authors:
+  - family-names: Krusell
+    given-names: Per
+  - family-names: Smith, Jr.
+    given-names: Anthony A.
+  title: Income and Wealth Heterogeneity in the Macroeconomy
+  doi: https://doi.org/10.1086/250034
+  date: 1998
+  publisher: Journal of political Economy
+github_repo_url: https://github.com/econ-ark/KrusellSmith
+remark-name: KrusellSmith
+notebooks:
+- Code/Python/KrusellSmith.ipynb
+tags:
+- REMARK
+- Notebook
+redirects_from:
+- /materials/Aiyagari
+- /materials/aiyagari
 ---
 
 

--- a/_materials/Alternative-Combos-Of-Parameter-Values.md
+++ b/_materials/Alternative-Combos-Of-Parameter-Values.md
@@ -1,22 +1,53 @@
 ---
 name: Alternative Combos Of Parameter Values
 tags:
-  - DemARK
-  - Demonstration
-  - Assignment
-  - Notebook
-abstract: "Alternative Combinations of Parameter Values of the cstwMPC model"
+- DemARK
+- Demonstration
+- Assignment
+- Notebook
+abstract: Alternative Combinations of Parameter Values of the cstwMPC model
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 date-released: 2018/09/12
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
-dashboards:
+- notebooks/Alternative-Combos-Of-Parameter-Values.ipynb
+dashboards: null
+redirects_from:
+- /materials/Alternative-Combos-Of-Parameter-Values
+- /materials/Alternative-Combos-Of-Parameter-values
+- /materials/Alternative-Combos-Of-parameter-Values
+- /materials/Alternative-Combos-Of-parameter-values
+- /materials/Alternative-Combos-of-Parameter-Values
+- /materials/Alternative-Combos-of-Parameter-values
+- /materials/Alternative-Combos-of-parameter-Values
+- /materials/Alternative-Combos-of-parameter-values
+- /materials/Alternative-combos-Of-Parameter-Values
+- /materials/Alternative-combos-Of-Parameter-values
+- /materials/Alternative-combos-Of-parameter-Values
+- /materials/Alternative-combos-Of-parameter-values
+- /materials/Alternative-combos-of-Parameter-Values
+- /materials/Alternative-combos-of-Parameter-values
+- /materials/Alternative-combos-of-parameter-Values
+- /materials/Alternative-combos-of-parameter-values
+- /materials/alternative-Combos-Of-Parameter-Values
+- /materials/alternative-Combos-Of-Parameter-values
+- /materials/alternative-Combos-Of-parameter-Values
+- /materials/alternative-Combos-Of-parameter-values
+- /materials/alternative-Combos-of-Parameter-Values
+- /materials/alternative-Combos-of-Parameter-values
+- /materials/alternative-Combos-of-parameter-Values
+- /materials/alternative-Combos-of-parameter-values
+- /materials/alternative-combos-Of-Parameter-Values
+- /materials/alternative-combos-Of-Parameter-values
+- /materials/alternative-combos-Of-parameter-Values
+- /materials/alternative-combos-Of-parameter-values
+- /materials/alternative-combos-of-Parameter-Values
+- /materials/alternative-combos-of-Parameter-values
+- /materials/alternative-combos-of-parameter-Values
+- /materials/alternative-combos-of-parameter-values
 ---
 
 Alternative Combinations of Parameter Values of the cstwMPC model

--- a/_materials/BayerLuetticke.md
+++ b/_materials/BayerLuetticke.md
@@ -1,42 +1,36 @@
 ---
-# CFF Requires fields
-cff-version: 1.1.0 # required (don't change)
-authors: # required
-  -
-    family-names: "Lee"
-    given-names: "Seungcheol"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "Park"
-    given-names:  "Seungmoon" 
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: "Solving heterogeneous agent models in discrete time with many idiosyncratic states by perturbation methods" # required
-abstract: "Code that solves models from the paper of Bayer and Luetikke, \"Solving heterogeneous agent models in discrete time with many idiosyncratic states by perturbation methods\"." # optional
-date-released: 2021-02-02 # required
-
-# REMARK required fields
-remark-version: 1.0 # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Bayer"
-        given-names: "Christian"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Luetticke"
-        given-names: "Ralph"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Solving heterogeneous agent models in discrete time with many idiosyncratic states by perturbation methods" # required
-    date: 2018-07-14 # required
-    
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/BayerLuetticke # required
-remark-name: BayerLuetticke # required 
-
-tags: # Use the relavent tags
-  - REMARK
-  - Reproduction
+cff-version: 1.1.0
+authors:
+- family-names: Lee
+  given-names: Seungcheol
+- family-names: Park
+  given-names: Seungmoon
+title: Solving heterogeneous agent models in discrete time with many idiosyncratic
+  states by perturbation methods
+abstract: Code that solves models from the paper of Bayer and Luetikke, "Solving heterogeneous
+  agent models in discrete time with many idiosyncratic states by perturbation methods".
+date-released: 2021-02-02
+remark-version: 1.0
+references:
+- type: article
+  authors:
+  - family-names: Bayer
+    given-names: Christian
+  - family-names: Luetticke
+    given-names: Ralph
+  title: Solving heterogeneous agent models in discrete time with many idiosyncratic
+    states by perturbation methods
+  date: 2018-07-14
+github_repo_url: https://github.com/econ-ark/BayerLuetticke
+remark-name: BayerLuetticke
+tags:
+- REMARK
+- Reproduction
+redirects_from:
+- /materials/BayerLuetticke
+- /materials/Bayerluetticke
+- /materials/bayerLuetticke
+- /materials/bayerluetticke
 ---
 
 # Bayer Luetticke (2018)

--- a/_materials/BlanchardPA2019.md
+++ b/_materials/BlanchardPA2019.md
@@ -1,38 +1,32 @@
 ---
-# CFF Required fields
-cff-version: 1.1.0 # required (don't change):
-authors: # required
-  -
-    family-names: "Acalin"
-    given-names: "Julien"
-    orcid: https://orcid.org/0000-0002-6137-0537
-title: BlanchardPA2019 # required
-
-# REMARK fields
-remark-version: 1.1 # required - specify version of REMARK standard used
-references:  # required for replications; optional for reproductions; BibTex data from original paper
-  - type: Presidential Address
-    authors: # required
-      -
-        family-names: "Blanchard"
-        given-names: "Olivier"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Public Debt and Low Interest Rates" # required
-    doi: "https://doi.org/10.1257/aer.109.4.1197" # optional
-    date: 2019-04 # required
-    publisher: American Economic Review
-
-# Econ-ARK website fields?
-github_repo_url: https://github.com/econ-ark/BlanchardPA2019 # required
-remark-name: BlanchardPA2019 # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/BlanchardPA2019.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Replication
-
+cff-version: 1.1.0
+authors:
+- family-names: Acalin
+  given-names: Julien
+  orcid: https://orcid.org/0000-0002-6137-0537
+title: BlanchardPA2019
+remark-version: 1.1
+references:
+- type: Presidential Address
+  authors:
+  - family-names: Blanchard
+    given-names: Olivier
+  title: Public Debt and Low Interest Rates
+  doi: https://doi.org/10.1257/aer.109.4.1197
+  date: 2019-04
+  publisher: American Economic Review
+github_repo_url: https://github.com/econ-ark/BlanchardPA2019
+remark-name: BlanchardPA2019
+notebooks:
+- Code/Python/BlanchardPA2019.ipynb
+tags:
+- REMARK
+- Replication
+redirects_from:
+- /materials/BlanchardPA2019
+- /materials/Blanchardpa2019
+- /materials/blanchardPA2019
+- /materials/blanchardpa2019
 ---
 
 # Public Debt and Low Interest Rates

--- a/_materials/BufferStock-LifeCycle.md
+++ b/_materials/BufferStock-LifeCycle.md
@@ -1,45 +1,49 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  - 
-    family-names: "Yusuf"
-    given-names: "Suha Kulu"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  - 
-    family-names: "Son"
-    given-names: "Jeongwon (John)"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: BufferStock-LifeCycle # required
-
-# REMARK required fields
-remark-version: 1.0 # required - specify version of REMARK standard used
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Yusuf
+  given-names: Suha Kulu
+- family-names: Son
+  given-names: Jeongwon (John)
+title: BufferStock-LifeCycle
+remark-version: 1.0
 references:
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: "Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis" # required
-    doi: "https://doi.org/10.1162/003355397555109" # optional
-    date: 1997-02-01 # required
-    publisher: "The Quarterly Journal of Economics"
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/BufferStock-LifeCycle # required 
-remark-name: BufferStock-LifeCycle # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/BufferStock-LifeCycle.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Notebook
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: Buffer-Stock Saving and the Life Cycle/Permanent Income Hypothesis
+  doi: https://doi.org/10.1162/003355397555109
+  date: 1997-02-01
+  publisher: The Quarterly Journal of Economics
+github_repo_url: https://github.com/econ-ark/BufferStock-LifeCycle
+remark-name: BufferStock-LifeCycle
+notebooks:
+- Code/Python/BufferStock-LifeCycle.ipynb
+tags:
+- REMARK
+- Notebook
+redirects_from:
+- /materials/BufferStock-LifeCycle
+- /materials/BufferStock-Lifecycle
+- /materials/BufferStock-lifeCycle
+- /materials/BufferStock-lifecycle
+- /materials/Bufferstock-LifeCycle
+- /materials/Bufferstock-Lifecycle
+- /materials/Bufferstock-lifeCycle
+- /materials/Bufferstock-lifecycle
+- /materials/bufferStock-LifeCycle
+- /materials/bufferStock-Lifecycle
+- /materials/bufferStock-lifeCycle
+- /materials/bufferStock-lifecycle
+- /materials/bufferstock-LifeCycle
+- /materials/bufferstock-Lifecycle
+- /materials/bufferstock-lifeCycle
+- /materials/bufferstock-lifecycle
 ---
 
 # BufferStock-LifeCycle

--- a/_materials/BufferStockTheory-Problems.md
+++ b/_materials/BufferStockTheory-Problems.md
@@ -1,54 +1,55 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required (don't change)
-message: "BufferStockTheory problems in notebook context" # required
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-title: "Theoretical Foundations of Buffer Stock Saving: Problems" # required
-abstract: "This adds some PhD student problems to the BufferStockTheory repo" # abstract: optional
-date-released: 2022-01-24 # required
-
-# REMARK required fields
-remark-version: "1.0" # required
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: exercise
-    authors: # required
-    -
-      family-names: "Carroll"
-      given-names: "Christopher D."
-      orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: Theoretical Foundations of Buffer Stock Saving
-    doi: "https://doi.org/10.5281/zenodo.4088918" # optional
-    #    date: 20XX-XX-XX
-    #    publisher : "Publisher information"
-repository: https://github.com/econ-ark/BufferStockTheory # optional
-
-# Econ-ARK website fields? 
-github_repo_url: https://github.com/econ-ark/BufferStockTheory # required 
-remark-name: BufferStockTheory # required 
-title-original-paper: Theoretical Foundations of Buffer Stock Saving # optional 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/BufferStockTheory-Problems.ipynb
-
-identifiers-paper: # required for Replications; optional for Reproductions
-   - 
-      type: url 
-      value: https://llorracc.github.io/BufferStockTheory
-   - 
-      type: doi
-      value: "https://doi.org/10.5281/zenodo.4088918"
-date-published-original-paper: 2020-09-14 # required for Replications; optional for Reproductions
-
-tags: # Use the relavent tags
-  - REMARK
-
-keywords: # optional
-  - Problems
-
+cff-version: 1.1.0
+message: BufferStockTheory problems in notebook context
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+title: 'Theoretical Foundations of Buffer Stock Saving: Problems'
+abstract: This adds some PhD student problems to the BufferStockTheory repo
+date-released: 2022-01-24
+remark-version: '1.0'
+references:
+- type: exercise
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: Theoretical Foundations of Buffer Stock Saving
+  doi: https://doi.org/10.5281/zenodo.4088918
+repository: https://github.com/econ-ark/BufferStockTheory
+github_repo_url: https://github.com/econ-ark/BufferStockTheory
+remark-name: BufferStockTheory
+title-original-paper: Theoretical Foundations of Buffer Stock Saving
+notebooks:
+- Code/Python/BufferStockTheory-Problems.ipynb
+identifiers-paper:
+- type: url
+  value: https://llorracc.github.io/BufferStockTheory
+- type: doi
+  value: https://doi.org/10.5281/zenodo.4088918
+date-published-original-paper: 2020-09-14
+tags:
+- REMARK
+keywords:
+- Problems
+redirects_from:
+- /materials/BufferStockTheory-Problems
+- /materials/BufferStockTheory-problems
+- /materials/BufferStocktheory-Problems
+- /materials/BufferStocktheory-problems
+- /materials/BufferstockTheory-Problems
+- /materials/BufferstockTheory-problems
+- /materials/Bufferstocktheory-Problems
+- /materials/Bufferstocktheory-problems
+- /materials/bufferStockTheory-Problems
+- /materials/bufferStockTheory-problems
+- /materials/bufferStocktheory-Problems
+- /materials/bufferStocktheory-problems
+- /materials/bufferstockTheory-Problems
+- /materials/bufferstockTheory-problems
+- /materials/bufferstocktheory-Problems
+- /materials/bufferstocktheory-problems
 ---
 # BufferStockTheory-Problems
 

--- a/_materials/BufferStockTheory.md
+++ b/_materials/BufferStockTheory.md
@@ -1,57 +1,60 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required (don't change)
-message: "For a consumption/saving problem with transitory and permanent shocks and unbounded (CRRA) utility, this paper derives conditions under which a nondegenerate solution exists, and under which a target wealth ratio exists; all results are paired with illustrative numerical solutions." # required
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-title: BufferStockTheory # required
-date-released: 2020-10-11 # required
-abstract: "This paper builds foundations for rigorous and intuitive understanding of 'buffer stock' saving models (Bewley (1977)-like models with a wealth target), pairing each theoretical result with quantitative illustrations.  After describing conditions under which a consumption function exists, the paper articulates stricter Growth Impatience' conditions that guarantee alternative forms of stability --- either at the population level, or for individual consumers.  Together, the numerical tools and analytical results constitute a comprehensive toolkit for understanding buffer stock models." # abstract: optional
-
-# REMARK required fields
-remark-version: "1.0" # required
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-    -
-      family-names: "Carroll"
-      given-names: "Christopher D."
-      orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: Theoretical Foundations of Buffer Stock Saving
-    doi: "https://doi.org/10.5281/zenodo.4088918" # optional
-    #    date: 20XX-XX-XX
-    #    publisher : "Publisher information"
-repository: https://github.com/econ-ark/BufferStockTheory # optional
-
-# Econ-ARK website fields? 
-github_repo_url: https://github.com/econ-ark/BufferStockTheory # required 
-remark-name: BufferStockTheory # required 
-title-original-paper: Theoretical Foundations of Buffer Stock Saving # optional 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    BufferStockTheory.ipynb
-dashboards: # path to any dahsboards within the repo - optional
-  - 
-    BufferStockTheory-dashboard.ipynb
-identifiers-paper: # required for Replications; optional for Reproductions
-   - 
-      type: url 
-      value: https://llorracc.github.io/BufferStockTheory
-   - 
-      type: doi
-      value: "https://doi.org/10.5281/zenodo.4088918"
-date-published-original-paper: 2020-09-14 # required for Replications; optional for Reproductions
-
-tags: # Use the relavent tags
-  - REMARK
-  - Reproduction
-
-keywords: # optional
-  - Consumption
-
+cff-version: 1.1.0
+message: For a consumption/saving problem with transitory and permanent shocks and
+  unbounded (CRRA) utility, this paper derives conditions under which a nondegenerate
+  solution exists, and under which a target wealth ratio exists; all results are paired
+  with illustrative numerical solutions.
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+title: BufferStockTheory
+date-released: 2020-10-11
+abstract: This paper builds foundations for rigorous and intuitive understanding of
+  'buffer stock' saving models (Bewley (1977)-like models with a wealth target), pairing
+  each theoretical result with quantitative illustrations.  After describing conditions
+  under which a consumption function exists, the paper articulates stricter Growth
+  Impatience' conditions that guarantee alternative forms of stability --- either
+  at the population level, or for individual consumers.  Together, the numerical tools
+  and analytical results constitute a comprehensive toolkit for understanding buffer
+  stock models.
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: Theoretical Foundations of Buffer Stock Saving
+  doi: https://doi.org/10.5281/zenodo.4088918
+repository: https://github.com/econ-ark/BufferStockTheory
+github_repo_url: https://github.com/econ-ark/BufferStockTheory
+remark-name: BufferStockTheory
+title-original-paper: Theoretical Foundations of Buffer Stock Saving
+notebooks:
+- BufferStockTheory.ipynb
+dashboards:
+- BufferStockTheory-dashboard.ipynb
+identifiers-paper:
+- type: url
+  value: https://llorracc.github.io/BufferStockTheory
+- type: doi
+  value: https://doi.org/10.5281/zenodo.4088918
+date-published-original-paper: 2020-09-14
+tags:
+- REMARK
+- Reproduction
+keywords:
+- Consumption
+redirects_from:
+- /materials/BufferStockTheory
+- /materials/BufferStocktheory
+- /materials/BufferstockTheory
+- /materials/Bufferstocktheory
+- /materials/bufferStockTheory
+- /materials/bufferStocktheory
+- /materials/bufferstockTheory
+- /materials/bufferstocktheory
 ---
 # BufferstockTheory
 "This paper builds foundations for rigorous and intuitive understanding of `buffer stock' saving models (Bewley (1977)-like models with a wealth target), pairing each theoretical result with quantitative illustrations.  After describing conditions under which a consumption function exists, the paper articulates stricter `Growth Impatience' conditions that guarantee alternative forms of stability --- either at the population level, or for individual consumers.  Together, the numerical tools and analytical results constitute a comprehensive toolkit for understanding buffer stock models.

--- a/_materials/CGMPortfolio.md
+++ b/_materials/CGMPortfolio.md
@@ -1,70 +1,57 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required 
-message: "For a consumption/saving problem with transitory and permanent shocks and unbounded (CRRA) utility, this paper derives conditions under which a nondegenerate solution exists, and under which a target wealth ratio exists; all results are paired with illustrative numerical solutions." # required
-authors: # required
-  -
-    family-names: "Velásquez-Giraldo"
-    given-names: "Mateo"
-    orcid: 0000-0001-7243-6776
-  -
-    family-names: "Zahn"
-    given-names: "Matthew"
-    orcid: 0000-0003-1148-2036
-title: "REMARK: Consumption and Portfolio Choice Over the Life Cycle" # required
-abstract: "This REMARK is an attempt to reproduce the main results of Cocco, Gomes, & Maenhout (2005), 'Consumption and Portfolio Choice Over the Life Cycle' (https://academic.oup.com/rfs/article-abstract/18/2/491/1599892)" # abstract: optional
-date-released: 2020-08-13 # required
-
-# REMARK required fields
-remark-version: 1.0 # required
-references: # Formatted metadata of original paper, from BibTex
-  - type: article
-    authors: # required
-      -
-        family-names: "Cocco"
-        given-names: "Joao F."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Gomes"
-        given-names: "Francisco J."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Maenhout"
-        given-names: "Pascal J."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Consumption and Portfolio Choice over the Life Cycle" # required
-    doi: "https://doi.org/10.1093/rfs/hhi017" # optional
-    date: 2005-02-10
-    publisher : "The Review of Financial Studies"
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/CGMPortfolio # required 
-remark-name: CGMPortfolio # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/CGMPortfolio.ipynb
-identifiers-paper: # required for Replications; optional for Reproductions
-   - 
-      type: url 
-      value: https://academic.oup.com/rfs/article-abstract/18/2/491/1599892
-   - 
-      type: doi
-      value: https://doi.org/10.1093/rfs/hhi017
-date-published-original-paper: 2005-02-10 # required for Replications; optional for Reproductions
-
-tags: # Use the relavent tags
-  - REMARK
-
-identifiers: # optional
-  - 
-    type: url
-    value: "https://github.com/econ-ark/CGMPortfolio"
-
-keywords: # optional
-  - Portfolio
-  - Risky Assets
-  - Consumption
-  - Life Cycle
+cff-version: 1.1.0
+message: For a consumption/saving problem with transitory and permanent shocks and
+  unbounded (CRRA) utility, this paper derives conditions under which a nondegenerate
+  solution exists, and under which a target wealth ratio exists; all results are paired
+  with illustrative numerical solutions.
+authors:
+- family-names: "Vel\xE1squez-Giraldo"
+  given-names: Mateo
+  orcid: 0000-0001-7243-6776
+- family-names: Zahn
+  given-names: Matthew
+  orcid: 0000-0003-1148-2036
+title: 'REMARK: Consumption and Portfolio Choice Over the Life Cycle'
+abstract: This REMARK is an attempt to reproduce the main results of Cocco, Gomes,
+  & Maenhout (2005), 'Consumption and Portfolio Choice Over the Life Cycle' (https://academic.oup.com/rfs/article-abstract/18/2/491/1599892)
+date-released: 2020-08-13
+remark-version: 1.0
+references:
+- type: article
+  authors:
+  - family-names: Cocco
+    given-names: Joao F.
+  - family-names: Gomes
+    given-names: Francisco J.
+  - family-names: Maenhout
+    given-names: Pascal J.
+  title: Consumption and Portfolio Choice over the Life Cycle
+  doi: https://doi.org/10.1093/rfs/hhi017
+  date: 2005-02-10
+  publisher: The Review of Financial Studies
+github_repo_url: https://github.com/econ-ark/CGMPortfolio
+remark-name: CGMPortfolio
+notebooks:
+- Code/Python/CGMPortfolio.ipynb
+identifiers-paper:
+- type: url
+  value: https://academic.oup.com/rfs/article-abstract/18/2/491/1599892
+- type: doi
+  value: https://doi.org/10.1093/rfs/hhi017
+date-published-original-paper: 2005-02-10
+tags:
+- REMARK
+identifiers:
+- type: url
+  value: https://github.com/econ-ark/CGMPortfolio
+keywords:
+- Portfolio
+- Risky Assets
+- Consumption
+- Life Cycle
+redirects_from:
+- /materials/CGMPortfolio
+- /materials/cgmportfolio
 ---
 
 # CGMPortfolio

--- a/_materials/ChangeLiqConstr.md
+++ b/_materials/ChangeLiqConstr.md
@@ -1,21 +1,29 @@
 ---
 name: Change Liq Constr
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'What Happens To the Consumption Function When A Liquidity Constraint is Tightened?'
+- DemARK
+- Demonstration
+- Notebook
+abstract: What Happens To the Consumption Function When A Liquidity Constraint is
+  Tightened?
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-date-released: 
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/ChangeLiqConstr.ipynb
-dashboards:
+- notebooks/ChangeLiqConstr.ipynb
+dashboards: null
+redirects_from:
+- /materials/ChangeLiqConstr
+- /materials/ChangeLiqconstr
+- /materials/ChangeliqConstr
+- /materials/Changeliqconstr
+- /materials/changeLiqConstr
+- /materials/changeLiqconstr
+- /materials/changeliqConstr
+- /materials/changeliqconstr
 ---
 
 What Happens To the Consumption Function When A Liquidity Constraint is Tightened?

--- a/_materials/Chinese-Growth.md
+++ b/_materials/Chinese-Growth.md
@@ -1,21 +1,24 @@
 ---
 name: Chinese Growth
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: "Do Precautionary Motives Explain China's High Saving Rate?"
+- DemARK
+- Demonstration
+- Notebook
+abstract: Do Precautionary Motives Explain China's High Saving Rate?
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-date-released: 
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Chinese-Growth.ipynb
-dashboards:
+- notebooks/Chinese-Growth.ipynb
+dashboards: null
+redirects_from:
+- /materials/Chinese-Growth
+- /materials/Chinese-growth
+- /materials/chinese-Growth
+- /materials/chinese-growth
 ---
 
 Do Precautionary Motives Explain China's High Saving Rate ?

--- a/_materials/ConsAggShockModel.md
+++ b/_materials/ConsAggShockModel.md
@@ -1,22 +1,37 @@
 ---
 name: ConsAggShockModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsAggShockModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsAggShockModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsAggShockModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsAggShockModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsAggShockModel
+- /materials/ConsAggShockmodel
+- /materials/ConsAggshockModel
+- /materials/ConsAggshockmodel
+- /materials/ConsaggShockModel
+- /materials/ConsaggShockmodel
+- /materials/ConsaggshockModel
+- /materials/Consaggshockmodel
+- /materials/consAggShockModel
+- /materials/consAggShockmodel
+- /materials/consAggshockModel
+- /materials/consAggshockmodel
+- /materials/consaggShockModel
+- /materials/consaggShockmodel
+- /materials/consaggshockModel
+- /materials/consaggshockmodel
 ---
 
 Detailed description of `ConsAggShockModel` 

--- a/_materials/ConsGenIncProcessModel.md
+++ b/_materials/ConsGenIncProcessModel.md
@@ -1,22 +1,53 @@
 ---
 name: ConsGenIncProcessModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsGenIncProcessModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsGenIncProcessModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsGenIncProcessModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsGenIncProcessModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsGenIncProcessModel
+- /materials/ConsGenIncProcessmodel
+- /materials/ConsGenIncprocessModel
+- /materials/ConsGenIncprocessmodel
+- /materials/ConsGenincProcessModel
+- /materials/ConsGenincProcessmodel
+- /materials/ConsGenincprocessModel
+- /materials/ConsGenincprocessmodel
+- /materials/ConsgenIncProcessModel
+- /materials/ConsgenIncProcessmodel
+- /materials/ConsgenIncprocessModel
+- /materials/ConsgenIncprocessmodel
+- /materials/ConsgenincProcessModel
+- /materials/ConsgenincProcessmodel
+- /materials/ConsgenincprocessModel
+- /materials/Consgenincprocessmodel
+- /materials/consGenIncProcessModel
+- /materials/consGenIncProcessmodel
+- /materials/consGenIncprocessModel
+- /materials/consGenIncprocessmodel
+- /materials/consGenincProcessModel
+- /materials/consGenincProcessmodel
+- /materials/consGenincprocessModel
+- /materials/consGenincprocessmodel
+- /materials/consgenIncProcessModel
+- /materials/consgenIncProcessmodel
+- /materials/consgenIncprocessModel
+- /materials/consgenIncprocessmodel
+- /materials/consgenincProcessModel
+- /materials/consgenincProcessmodel
+- /materials/consgenincprocessModel
+- /materials/consgenincprocessmodel
 ---
 
 Detailed description of `ConsGenIncProcessModel` 

--- a/_materials/ConsIndShock.md
+++ b/_materials/ConsIndShock.md
@@ -1,22 +1,29 @@
 ---
 name: ConsIndShock
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsIndShock Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsIndShock Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsIndShock.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsIndShock.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsIndShock
+- /materials/ConsIndshock
+- /materials/ConsindShock
+- /materials/Consindshock
+- /materials/consIndShock
+- /materials/consIndshock
+- /materials/consindShock
+- /materials/consindshock
 ---
 
 Detailed description of `ConsIndShock` 

--- a/_materials/ConsLaborModel.md
+++ b/_materials/ConsLaborModel.md
@@ -1,22 +1,29 @@
 ---
 name: ConsLaborModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsLaborModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsLaborModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsLaborModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsLaborModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsLaborModel
+- /materials/ConsLabormodel
+- /materials/ConslaborModel
+- /materials/Conslabormodel
+- /materials/consLaborModel
+- /materials/consLabormodel
+- /materials/conslaborModel
+- /materials/conslabormodel
 ---
 
 Detailed description of `ConsLaborModel` 

--- a/_materials/ConsMarkovModel.md
+++ b/_materials/ConsMarkovModel.md
@@ -1,22 +1,29 @@
 ---
 name: ConsMarkovModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsMarkovModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsMarkovModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsMarkovModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsMarkovModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsMarkovModel
+- /materials/ConsMarkovmodel
+- /materials/ConsmarkovModel
+- /materials/Consmarkovmodel
+- /materials/consMarkovModel
+- /materials/consMarkovmodel
+- /materials/consmarkovModel
+- /materials/consmarkovmodel
 ---
 
 Detailed description of `ConsMarkovModel` 

--- a/_materials/ConsMedModel.md
+++ b/_materials/ConsMedModel.md
@@ -1,22 +1,29 @@
 ---
 name: ConsMedModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsMedModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsMedModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsMedModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsMedModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsMedModel
+- /materials/ConsMedmodel
+- /materials/ConsmedModel
+- /materials/Consmedmodel
+- /materials/consMedModel
+- /materials/consMedmodel
+- /materials/consmedModel
+- /materials/consmedmodel
 ---
 
 Detailed description of `ConsMedModel` 

--- a/_materials/ConsPortfolioModel.md
+++ b/_materials/ConsPortfolioModel.md
@@ -1,22 +1,29 @@
 ---
 name: ConsPortfolioModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsPortfolioModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsPortfolioModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsPortfolioModel/ConsPortfolioModel.ipynb
-dashboards:
+- examples/ConsPortfolioModel/ConsPortfolioModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsPortfolioModel
+- /materials/ConsPortfoliomodel
+- /materials/ConsportfolioModel
+- /materials/Consportfoliomodel
+- /materials/consPortfolioModel
+- /materials/consPortfoliomodel
+- /materials/consportfolioModel
+- /materials/consportfoliomodel
 ---
 
 Detailed description of the `ConsPortfolioModel` package

--- a/_materials/ConsPrefShockModel.md
+++ b/_materials/ConsPrefShockModel.md
@@ -1,22 +1,37 @@
 ---
 name: ConsPrefShockModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsPrefShockModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsPrefShockModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsPrefShockModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsPrefShockModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsPrefShockModel
+- /materials/ConsPrefShockmodel
+- /materials/ConsPrefshockModel
+- /materials/ConsPrefshockmodel
+- /materials/ConsprefShockModel
+- /materials/ConsprefShockmodel
+- /materials/ConsprefshockModel
+- /materials/Consprefshockmodel
+- /materials/consPrefShockModel
+- /materials/consPrefShockmodel
+- /materials/consPrefshockModel
+- /materials/consPrefshockmodel
+- /materials/consprefShockModel
+- /materials/consprefShockmodel
+- /materials/consprefshockModel
+- /materials/consprefshockmodel
 ---
 
 Detailed description of `ConsPrefShockModel` 

--- a/_materials/ConsRepAgentModel.md
+++ b/_materials/ConsRepAgentModel.md
@@ -1,22 +1,37 @@
 ---
 name: ConsRepAgentModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsRepAgentModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsRepAgentModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsRepAgentModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsRepAgentModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsRepAgentModel
+- /materials/ConsRepAgentmodel
+- /materials/ConsRepagentModel
+- /materials/ConsRepagentmodel
+- /materials/ConsrepAgentModel
+- /materials/ConsrepAgentmodel
+- /materials/ConsrepagentModel
+- /materials/Consrepagentmodel
+- /materials/consRepAgentModel
+- /materials/consRepAgentmodel
+- /materials/consRepagentModel
+- /materials/consRepagentmodel
+- /materials/consrepAgentModel
+- /materials/consrepAgentmodel
+- /materials/consrepagentModel
+- /materials/consrepagentmodel
 ---
 
 Detailed description of `ConsRepAgentModel` 

--- a/_materials/ConsRiskyContribModel.md
+++ b/_materials/ConsRiskyContribModel.md
@@ -1,22 +1,37 @@
 ---
 name: ConsRiskyContribModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsRiskyContribModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsRiskyContribModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_ConsRiskyContribModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_ConsRiskyContribModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsRiskyContribModel
+- /materials/ConsRiskyContribmodel
+- /materials/ConsRiskycontribModel
+- /materials/ConsRiskycontribmodel
+- /materials/ConsriskyContribModel
+- /materials/ConsriskyContribmodel
+- /materials/ConsriskycontribModel
+- /materials/Consriskycontribmodel
+- /materials/consRiskyContribModel
+- /materials/consRiskyContribmodel
+- /materials/consRiskycontribModel
+- /materials/consRiskycontribmodel
+- /materials/consriskyContribModel
+- /materials/consriskyContribmodel
+- /materials/consriskycontribModel
+- /materials/consriskycontribmodel
 ---
 
 Detailed description of `ConsRiskyContribModel` 

--- a/_materials/ConsSequentialPortfolioModel.md
+++ b/_materials/ConsSequentialPortfolioModel.md
@@ -1,22 +1,37 @@
 ---
 name: ConsSequentialPortfolioModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'ConsSequentialPortfolioModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: ConsSequentialPortfolioModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsSequentialPortfolioModel/ConsSequentialPortfolioModel.ipynb
-dashboards:
+- examples/ConsSequentialPortfolioModel/ConsSequentialPortfolioModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/ConsSequentialPortfolioModel
+- /materials/ConsSequentialPortfoliomodel
+- /materials/ConsSequentialportfolioModel
+- /materials/ConsSequentialportfoliomodel
+- /materials/ConssequentialPortfolioModel
+- /materials/ConssequentialPortfoliomodel
+- /materials/ConssequentialportfolioModel
+- /materials/Conssequentialportfoliomodel
+- /materials/consSequentialPortfolioModel
+- /materials/consSequentialPortfoliomodel
+- /materials/consSequentialportfolioModel
+- /materials/consSequentialportfoliomodel
+- /materials/conssequentialPortfolioModel
+- /materials/conssequentialPortfoliomodel
+- /materials/conssequentialportfolioModel
+- /materials/conssequentialportfoliomodel
 ---
 
 Detailed description of the `ConsSequentialPortfolioModel` package

--- a/_materials/DCEGM-Upper-Envelope.md
+++ b/_materials/DCEGM-Upper-Envelope.md
@@ -1,34 +1,39 @@
 ---
 name: DCEGM-Upper-Envelope
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'DCEGM Upper Envelope'
+- DemARK
+- Demonstration
+- Notebook
+abstract: DCEGM Upper Envelope
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Velásquez-Giraldo"
-    given-names: "Mateo"
-    orcid: "https://orcid.org/0000-0001-7243-6776"
-date-released:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: "Vel\xE1squez-Giraldo"
+  given-names: Mateo
+  orcid: https://orcid.org/0000-0001-7243-6776
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/DCEGM-Upper-Envelope.ipynb
-dashboards:
-title-original-paper: The endogenous grid method for discrete-continuous dynamic choice models with (or without) taste shocks # required for Replications
-identifiers-paper: # required for Replications; optional for Reproductions
-   -
-      type: url
-      value: https://onlinelibrary.wiley.com/doi/abs/10.3982/QE643
-   -
-      type: doi
-      value: https://doi.org/10.3982/QE643
-date-published-original-paper: 2017-07 # required for Replications; optional for Reproductions
+- notebooks/DCEGM-Upper-Envelope.ipynb
+dashboards: null
+title-original-paper: The endogenous grid method for discrete-continuous dynamic choice
+  models with (or without) taste shocks
+identifiers-paper:
+- type: url
+  value: https://onlinelibrary.wiley.com/doi/abs/10.3982/QE643
+- type: doi
+  value: https://doi.org/10.3982/QE643
+date-published-original-paper: 2017-07
+redirects_from:
+- /materials/DCEGM-Upper-Envelope
+- /materials/DCEGM-Upper-envelope
+- /materials/DCEGM-upper-Envelope
+- /materials/DCEGM-upper-envelope
+- /materials/dcegm-Upper-Envelope
+- /materials/dcegm-Upper-envelope
+- /materials/dcegm-upper-Envelope
+- /materials/dcegm-upper-envelope
 ---
 
 DCEGM Upper Envelope

--- a/_materials/DiamondOLG.md
+++ b/_materials/DiamondOLG.md
@@ -1,21 +1,24 @@
 ---
 name: DiamondOLG
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'The Diamond OLG Model'
+- DemARK
+- Demonstration
+- Notebook
+abstract: The Diamond OLG Model
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-date-released: 
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/DiamondOLG.ipynb
-dashboards:
+- notebooks/DiamondOLG.ipynb
+dashboards: null
+redirects_from:
+- /materials/DiamondOLG
+- /materials/Diamondolg
+- /materials/diamondOLG
+- /materials/diamondolg
 ---
 
 The Diamond (1965) OLG Model

--- a/_materials/DistributionOfWealthMPC.md
+++ b/_materials/DistributionOfWealthMPC.md
@@ -1,59 +1,58 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-message: The results of this paper are now generated in an updated repository using a more modern version of HARK, https://github.com/econ-ark/DistributionOfWealthMPC. Any followup work should build on the updated code in that repository. # optional
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Slacalek"
-    given-names: "Jiri"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "Kiichi"
-    given-names: "Tokuoka"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "White"
-    given-names: "Matthew"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
+cff-version: 1.1.0
+message: The results of this paper are now generated in an updated repository using
+  a more modern version of HARK, https://github.com/econ-ark/DistributionOfWealthMPC.
+  Any followup work should build on the updated code in that repository.
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Slacalek
+  given-names: Jiri
+- family-names: Kiichi
+  given-names: Tokuoka
+- family-names: White
+  given-names: Matthew
 title: DistributionOfWealthMPC
-
-# REMARK required fields
 remark-version: 2.0
-references: 
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Slacalek"
-        given-names: "Jiri"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Kiichi"
-        given-names: "Tokuoka"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "White"
-        given-names: "Matthew N."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "The distribution of wealth and the marginal propensity to consume" # required
-    doi: "https://doi.org/10.3982/QE694"
-    date: 2017-11-20
-    publisher: Quantitative Economics
-
-# Econ-ARK website fields
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Slacalek
+    given-names: Jiri
+  - family-names: Kiichi
+    given-names: Tokuoka
+  - family-names: White
+    given-names: Matthew N.
+  title: The distribution of wealth and the marginal propensity to consume
+  doi: https://doi.org/10.3982/QE694
+  date: 2017-11-20
+  publisher: Quantitative Economics
 github_repo_url: https://github.com/econ-ark/DistributionOfWealthMPC
 remark-name: DistributionofWealthMPC
-
-tags: # Use the relavent tags
-  - REMARK
-  - Replication
+tags:
+- REMARK
+- Replication
+redirects_from:
+- /materials/DistributionOfWealthMPC
+- /materials/DistributionOfWealthmpc
+- /materials/DistributionOfwealthMPC
+- /materials/DistributionOfwealthmpc
+- /materials/DistributionofWealthMPC
+- /materials/DistributionofWealthmpc
+- /materials/DistributionofwealthMPC
+- /materials/Distributionofwealthmpc
+- /materials/distributionOfWealthMPC
+- /materials/distributionOfWealthmpc
+- /materials/distributionOfwealthMPC
+- /materials/distributionOfwealthmpc
+- /materials/distributionofWealthMPC
+- /materials/distributionofWealthmpc
+- /materials/distributionofwealthMPC
+- /materials/distributionofwealthmpc
 ---
 
 

--- a/_materials/EndogenousRetirement.md
+++ b/_materials/EndogenousRetirement.md
@@ -1,35 +1,30 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-authors: # required
-  - family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-title: EndogenousRetirement # required
-
-# REMARK required fields
-remark-version: "1.0" # required - specify version of REMARK standard used
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+title: EndogenousRetirement
+remark-version: '1.0'
 references:
-  - type: article
-    authors: # required
-    -
-      family-names: "Carroll"
-      given-names: "Christopher D."
-      orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: "Endogenous Retirement: A Canonical Discrete-Continuous Problem" # required
-    # doi: ""
-    # date: ""
-    # publisher: ""
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/EndogenousRetirement # required
-remark-name: EndogeneousRetirement # required
-notebook: # path to any notebooks within the repo - optional
-  - Endogenous-Retirement.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Reproduction
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: 'Endogenous Retirement: A Canonical Discrete-Continuous Problem'
+github_repo_url: https://github.com/econ-ark/EndogenousRetirement
+remark-name: EndogeneousRetirement
+notebook:
+- Endogenous-Retirement.ipynb
+tags:
+- REMARK
+- Reproduction
+redirects_from:
+- /materials/EndogenousRetirement
+- /materials/Endogenousretirement
+- /materials/endogenousRetirement
+- /materials/endogenousretirement
 ---
 
 # Endogenous Retirement: A Canonical Discrete-Continuous Problem

--- a/_materials/EpiExp.md
+++ b/_materials/EpiExp.md
@@ -1,56 +1,53 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required 
-message: "Repository to reproduce results and text of paper" # required
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Wang"
-    given-names: "Tao"
-    orcid: "https://orcid.org/0000-0003-4806-8592"
-title: "Epidemiological Expectations in Economics" # required
-abstract: "‘Epidemiological’ models of belief formation put social interactions at their core; such models are the main (almost, the only) tool used by non-economists to study the dynamics of beliefs in populations. We survey the (comparatively) small literature in which economists attempting to model the consequences of beliefs about the future – ‘expectations’ – have employed what we view as a full-fledged epidemiological approach to explore an economic question. We draw connections to related work on narrative economics, news/rumor spreading, ‘contagion,’ and the spread of online content. Finally, we discuss a number of promising directions for future research." # abstract: optional
-date-released: 2021-09-29 # required
-
-# REMARK required fields
-remark-version: "1.0"
+cff-version: 1.1.0
+message: Repository to reproduce results and text of paper
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Wang
+  given-names: Tao
+  orcid: https://orcid.org/0000-0003-4806-8592
+title: Epidemiological Expectations in Economics
+abstract: "\u2018Epidemiological\u2019 models of belief formation put social interactions\
+  \ at their core; such models are the main (almost, the only) tool used by non-economists\
+  \ to study the dynamics of beliefs in populations. We survey the (comparatively)\
+  \ small literature in which economists attempting to model the consequences of beliefs\
+  \ about the future \u2013 \u2018expectations\u2019 \u2013 have employed what we\
+  \ view as a full-fledged epidemiological approach to explore an economic question.\
+  \ We draw connections to related work on narrative economics, news/rumor spreading,\
+  \ \u2018contagion,\u2019 and the spread of online content. Finally, we discuss a\
+  \ number of promising directions for future research."
+date-released: 2021-09-29
+remark-version: '1.0'
 references:
-  - type: Handbook-Chapter
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Wang"
-        given-names: "Tao"
-        orcid: "https://orcid.org/0000-0003-4806-8592"
-    title: "Epidemiological Expectations in Economics" # required
-    # doi: "Original paper DOI" # optional
-    date: 2022-03-22 # required
-    # publisher: "Publisher information"
-
-# Econ-ARK website fields
-github_repo_url: "https://github.com/econ-ark/EpiExp"
+- type: Handbook-Chapter
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Wang
+    given-names: Tao
+    orcid: https://orcid.org/0000-0003-4806-8592
+  title: Epidemiological Expectations in Economics
+  date: 2022-03-22
+github_repo_url: https://github.com/econ-ark/EpiExp
 Remark-name: EpiExp
 notebooks:
-  - SIR_Ndlib.ipynb
-
+- SIR_Ndlib.ipynb
 identifiers-paper:
-  -
-    type: doi
-    value: https://doi.org/10.5281/zenodo.6363391
-
-tags: # Use the relavent tags
-  - REMARK
-
-keywords: # optional
-  - Epidemiology
-  - Expectations
-  
+- type: doi
+  value: https://doi.org/10.5281/zenodo.6363391
+tags:
+- REMARK
+keywords:
+- Epidemiology
+- Expectations
+redirects_from:
+- /materials/EpiExp
+- /materials/Epiexp
+- /materials/epiExp
+- /materials/epiexp
 ---
 
 # EpiExp

--- a/_materials/FisherTwoPeriod.md
+++ b/_materials/FisherTwoPeriod.md
@@ -1,22 +1,29 @@
 ---
 name: FisherTwoPeriod
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
-abstract: 'The Fisher Two-Period Optimal Consumption Problem'
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
+abstract: The Fisher Two-Period Optimal Consumption Problem
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-date-released: 
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/FisherTwoPeriod.ipynb
-dashboards:
+- notebooks/FisherTwoPeriod.ipynb
+dashboards: null
+redirects_from:
+- /materials/FisherTwoPeriod
+- /materials/FisherTwoperiod
+- /materials/FishertwoPeriod
+- /materials/Fishertwoperiod
+- /materials/fisherTwoPeriod
+- /materials/fisherTwoperiod
+- /materials/fishertwoPeriod
+- /materials/fishertwoperiod
 ---
 
 The Fisher Two-Period Optimal Consumption Problem

--- a/_materials/GanongNoelUI.md
+++ b/_materials/GanongNoelUI.md
@@ -1,43 +1,39 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-# message: If you use this software, please cite it as below. # optional
-authors: # required
-  - family-names: "Ganong"
-    given-names: "Peter"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  - family-names: "Noel"
-    given-names: "Pascal"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: GanongNoelUI # required
-
-# REMARK required fields
-remark-version: "1.0" # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Ganong"
-        given-names: "Peter"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Noel"
-        given-names: "Pascal"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Consumer Spending During Unemployment: Positive and Normative Implications" # required
-    doi: "https://doi.org/10.1257/aer.20170537" # optional
-    date: 2019-07 # required
-    publisher: "The American Economic Review"
-
-# Econ-ARK website fields 
-github_repo_url: "https://github.com/econ-ark/REMARK" # required 
-remark-name: "GanongNoelUI" # required
-title-original-paper: "Consumer Spending During Unemployment: Positive and Normative Implications" # optional 
-
-tags:  # Use the relavent tags
-  - REMARK
-  - Replication
-
+cff-version: 1.1.0
+authors:
+- family-names: Ganong
+  given-names: Peter
+- family-names: Noel
+  given-names: Pascal
+title: GanongNoelUI
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Ganong
+    given-names: Peter
+  - family-names: Noel
+    given-names: Pascal
+  title: 'Consumer Spending During Unemployment: Positive and Normative Implications'
+  doi: https://doi.org/10.1257/aer.20170537
+  date: 2019-07
+  publisher: The American Economic Review
+github_repo_url: https://github.com/econ-ark/REMARK
+remark-name: GanongNoelUI
+title-original-paper: 'Consumer Spending During Unemployment: Positive and Normative
+  Implications'
+tags:
+- REMARK
+- Replication
+redirects_from:
+- /materials/GanongNoelUI
+- /materials/GanongNoelui
+- /materials/GanongnoelUI
+- /materials/Ganongnoelui
+- /materials/ganongNoelUI
+- /materials/ganongNoelui
+- /materials/ganongnoelUI
+- /materials/ganongnoelui
 ---
   
   Analysis of Models for "Consumer Spending During Unemployment: Positive and Normative Implications"

--- a/_materials/Gentle-Intro-To-HARK-Buffer-Stock-Model.md
+++ b/_materials/Gentle-Intro-To-HARK-Buffer-Stock-Model.md
@@ -1,22 +1,149 @@
 ---
 name: Gentle-Intro-To-HARK-Buffer-Stock-Model
 tags:
-  - DemARK
-  - Demonstration
-  - Tutorial
-  - Teaching
-  - Notebook
-abstract: 'A Gentle Introduction to Buffer Stock Saving'
+- DemARK
+- Demonstration
+- Tutorial
+- Teaching
+- Notebook
+abstract: A Gentle Introduction to Buffer Stock Saving
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Gentle-Intro-To-HARK-Buffer-Stock-Model.ipynb
-dashboards:
+- notebooks/Gentle-Intro-To-HARK-Buffer-Stock-Model.ipynb
+dashboards: null
+redirects_from:
+- /materials/Gentle-Intro-To-HARK-Buffer-Stock-Model
+- /materials/Gentle-Intro-To-HARK-Buffer-Stock-model
+- /materials/Gentle-Intro-To-HARK-Buffer-stock-Model
+- /materials/Gentle-Intro-To-HARK-Buffer-stock-model
+- /materials/Gentle-Intro-To-HARK-buffer-Stock-Model
+- /materials/Gentle-Intro-To-HARK-buffer-Stock-model
+- /materials/Gentle-Intro-To-HARK-buffer-stock-Model
+- /materials/Gentle-Intro-To-HARK-buffer-stock-model
+- /materials/Gentle-Intro-To-hark-Buffer-Stock-Model
+- /materials/Gentle-Intro-To-hark-Buffer-Stock-model
+- /materials/Gentle-Intro-To-hark-Buffer-stock-Model
+- /materials/Gentle-Intro-To-hark-Buffer-stock-model
+- /materials/Gentle-Intro-To-hark-buffer-Stock-Model
+- /materials/Gentle-Intro-To-hark-buffer-Stock-model
+- /materials/Gentle-Intro-To-hark-buffer-stock-Model
+- /materials/Gentle-Intro-To-hark-buffer-stock-model
+- /materials/Gentle-Intro-to-HARK-Buffer-Stock-Model
+- /materials/Gentle-Intro-to-HARK-Buffer-Stock-model
+- /materials/Gentle-Intro-to-HARK-Buffer-stock-Model
+- /materials/Gentle-Intro-to-HARK-Buffer-stock-model
+- /materials/Gentle-Intro-to-HARK-buffer-Stock-Model
+- /materials/Gentle-Intro-to-HARK-buffer-Stock-model
+- /materials/Gentle-Intro-to-HARK-buffer-stock-Model
+- /materials/Gentle-Intro-to-HARK-buffer-stock-model
+- /materials/Gentle-Intro-to-hark-Buffer-Stock-Model
+- /materials/Gentle-Intro-to-hark-Buffer-Stock-model
+- /materials/Gentle-Intro-to-hark-Buffer-stock-Model
+- /materials/Gentle-Intro-to-hark-Buffer-stock-model
+- /materials/Gentle-Intro-to-hark-buffer-Stock-Model
+- /materials/Gentle-Intro-to-hark-buffer-Stock-model
+- /materials/Gentle-Intro-to-hark-buffer-stock-Model
+- /materials/Gentle-Intro-to-hark-buffer-stock-model
+- /materials/Gentle-intro-To-HARK-Buffer-Stock-Model
+- /materials/Gentle-intro-To-HARK-Buffer-Stock-model
+- /materials/Gentle-intro-To-HARK-Buffer-stock-Model
+- /materials/Gentle-intro-To-HARK-Buffer-stock-model
+- /materials/Gentle-intro-To-HARK-buffer-Stock-Model
+- /materials/Gentle-intro-To-HARK-buffer-Stock-model
+- /materials/Gentle-intro-To-HARK-buffer-stock-Model
+- /materials/Gentle-intro-To-HARK-buffer-stock-model
+- /materials/Gentle-intro-To-hark-Buffer-Stock-Model
+- /materials/Gentle-intro-To-hark-Buffer-Stock-model
+- /materials/Gentle-intro-To-hark-Buffer-stock-Model
+- /materials/Gentle-intro-To-hark-Buffer-stock-model
+- /materials/Gentle-intro-To-hark-buffer-Stock-Model
+- /materials/Gentle-intro-To-hark-buffer-Stock-model
+- /materials/Gentle-intro-To-hark-buffer-stock-Model
+- /materials/Gentle-intro-To-hark-buffer-stock-model
+- /materials/Gentle-intro-to-HARK-Buffer-Stock-Model
+- /materials/Gentle-intro-to-HARK-Buffer-Stock-model
+- /materials/Gentle-intro-to-HARK-Buffer-stock-Model
+- /materials/Gentle-intro-to-HARK-Buffer-stock-model
+- /materials/Gentle-intro-to-HARK-buffer-Stock-Model
+- /materials/Gentle-intro-to-HARK-buffer-Stock-model
+- /materials/Gentle-intro-to-HARK-buffer-stock-Model
+- /materials/Gentle-intro-to-HARK-buffer-stock-model
+- /materials/Gentle-intro-to-hark-Buffer-Stock-Model
+- /materials/Gentle-intro-to-hark-Buffer-Stock-model
+- /materials/Gentle-intro-to-hark-Buffer-stock-Model
+- /materials/Gentle-intro-to-hark-Buffer-stock-model
+- /materials/Gentle-intro-to-hark-buffer-Stock-Model
+- /materials/Gentle-intro-to-hark-buffer-Stock-model
+- /materials/Gentle-intro-to-hark-buffer-stock-Model
+- /materials/Gentle-intro-to-hark-buffer-stock-model
+- /materials/gentle-Intro-To-HARK-Buffer-Stock-Model
+- /materials/gentle-Intro-To-HARK-Buffer-Stock-model
+- /materials/gentle-Intro-To-HARK-Buffer-stock-Model
+- /materials/gentle-Intro-To-HARK-Buffer-stock-model
+- /materials/gentle-Intro-To-HARK-buffer-Stock-Model
+- /materials/gentle-Intro-To-HARK-buffer-Stock-model
+- /materials/gentle-Intro-To-HARK-buffer-stock-Model
+- /materials/gentle-Intro-To-HARK-buffer-stock-model
+- /materials/gentle-Intro-To-hark-Buffer-Stock-Model
+- /materials/gentle-Intro-To-hark-Buffer-Stock-model
+- /materials/gentle-Intro-To-hark-Buffer-stock-Model
+- /materials/gentle-Intro-To-hark-Buffer-stock-model
+- /materials/gentle-Intro-To-hark-buffer-Stock-Model
+- /materials/gentle-Intro-To-hark-buffer-Stock-model
+- /materials/gentle-Intro-To-hark-buffer-stock-Model
+- /materials/gentle-Intro-To-hark-buffer-stock-model
+- /materials/gentle-Intro-to-HARK-Buffer-Stock-Model
+- /materials/gentle-Intro-to-HARK-Buffer-Stock-model
+- /materials/gentle-Intro-to-HARK-Buffer-stock-Model
+- /materials/gentle-Intro-to-HARK-Buffer-stock-model
+- /materials/gentle-Intro-to-HARK-buffer-Stock-Model
+- /materials/gentle-Intro-to-HARK-buffer-Stock-model
+- /materials/gentle-Intro-to-HARK-buffer-stock-Model
+- /materials/gentle-Intro-to-HARK-buffer-stock-model
+- /materials/gentle-Intro-to-hark-Buffer-Stock-Model
+- /materials/gentle-Intro-to-hark-Buffer-Stock-model
+- /materials/gentle-Intro-to-hark-Buffer-stock-Model
+- /materials/gentle-Intro-to-hark-Buffer-stock-model
+- /materials/gentle-Intro-to-hark-buffer-Stock-Model
+- /materials/gentle-Intro-to-hark-buffer-Stock-model
+- /materials/gentle-Intro-to-hark-buffer-stock-Model
+- /materials/gentle-Intro-to-hark-buffer-stock-model
+- /materials/gentle-intro-To-HARK-Buffer-Stock-Model
+- /materials/gentle-intro-To-HARK-Buffer-Stock-model
+- /materials/gentle-intro-To-HARK-Buffer-stock-Model
+- /materials/gentle-intro-To-HARK-Buffer-stock-model
+- /materials/gentle-intro-To-HARK-buffer-Stock-Model
+- /materials/gentle-intro-To-HARK-buffer-Stock-model
+- /materials/gentle-intro-To-HARK-buffer-stock-Model
+- /materials/gentle-intro-To-HARK-buffer-stock-model
+- /materials/gentle-intro-To-hark-Buffer-Stock-Model
+- /materials/gentle-intro-To-hark-Buffer-Stock-model
+- /materials/gentle-intro-To-hark-Buffer-stock-Model
+- /materials/gentle-intro-To-hark-Buffer-stock-model
+- /materials/gentle-intro-To-hark-buffer-Stock-Model
+- /materials/gentle-intro-To-hark-buffer-Stock-model
+- /materials/gentle-intro-To-hark-buffer-stock-Model
+- /materials/gentle-intro-To-hark-buffer-stock-model
+- /materials/gentle-intro-to-HARK-Buffer-Stock-Model
+- /materials/gentle-intro-to-HARK-Buffer-Stock-model
+- /materials/gentle-intro-to-HARK-Buffer-stock-Model
+- /materials/gentle-intro-to-HARK-Buffer-stock-model
+- /materials/gentle-intro-to-HARK-buffer-Stock-Model
+- /materials/gentle-intro-to-HARK-buffer-Stock-model
+- /materials/gentle-intro-to-HARK-buffer-stock-Model
+- /materials/gentle-intro-to-HARK-buffer-stock-model
+- /materials/gentle-intro-to-hark-Buffer-Stock-Model
+- /materials/gentle-intro-to-hark-Buffer-Stock-model
+- /materials/gentle-intro-to-hark-Buffer-stock-Model
+- /materials/gentle-intro-to-hark-Buffer-stock-model
+- /materials/gentle-intro-to-hark-buffer-Stock-Model
+- /materials/gentle-intro-to-hark-buffer-Stock-model
+- /materials/gentle-intro-to-hark-buffer-stock-Model
+- /materials/gentle-intro-to-hark-buffer-stock-model
 ---
 
 A Gentle Introduction to Buffer Stock Saving

--- a/_materials/Gentle-Intro-To-HARK-PerfForesightCRRA.md
+++ b/_materials/Gentle-Intro-To-HARK-PerfForesightCRRA.md
@@ -1,21 +1,148 @@
 ---
 name: Gentle-Intro-To-HARK-PerfForesightCRRA
 tags:
-  - DemARK
-  - Demonstration
-  - Tutorial
-  - Notebook
-abstract: 'A Gentle Introduction to HARK In Perfect Foresight'
+- DemARK
+- Demonstration
+- Tutorial
+- Notebook
+abstract: A Gentle Introduction to HARK In Perfect Foresight
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Gentle-Intro-To-HARK-PerfForesightCRRA.ipynb
-dashboards:
+- notebooks/Gentle-Intro-To-HARK-PerfForesightCRRA.ipynb
+dashboards: null
+redirects_from:
+- /materials/Gentle-Intro-To-HARK-PerfForesightCRRA
+- /materials/Gentle-Intro-To-HARK-PerfForesightcrra
+- /materials/Gentle-Intro-To-HARK-PerfforesightCRRA
+- /materials/Gentle-Intro-To-HARK-Perfforesightcrra
+- /materials/Gentle-Intro-To-HARK-perfForesightCRRA
+- /materials/Gentle-Intro-To-HARK-perfForesightcrra
+- /materials/Gentle-Intro-To-HARK-perfforesightCRRA
+- /materials/Gentle-Intro-To-HARK-perfforesightcrra
+- /materials/Gentle-Intro-To-hark-PerfForesightCRRA
+- /materials/Gentle-Intro-To-hark-PerfForesightcrra
+- /materials/Gentle-Intro-To-hark-PerfforesightCRRA
+- /materials/Gentle-Intro-To-hark-Perfforesightcrra
+- /materials/Gentle-Intro-To-hark-perfForesightCRRA
+- /materials/Gentle-Intro-To-hark-perfForesightcrra
+- /materials/Gentle-Intro-To-hark-perfforesightCRRA
+- /materials/Gentle-Intro-To-hark-perfforesightcrra
+- /materials/Gentle-Intro-to-HARK-PerfForesightCRRA
+- /materials/Gentle-Intro-to-HARK-PerfForesightcrra
+- /materials/Gentle-Intro-to-HARK-PerfforesightCRRA
+- /materials/Gentle-Intro-to-HARK-Perfforesightcrra
+- /materials/Gentle-Intro-to-HARK-perfForesightCRRA
+- /materials/Gentle-Intro-to-HARK-perfForesightcrra
+- /materials/Gentle-Intro-to-HARK-perfforesightCRRA
+- /materials/Gentle-Intro-to-HARK-perfforesightcrra
+- /materials/Gentle-Intro-to-hark-PerfForesightCRRA
+- /materials/Gentle-Intro-to-hark-PerfForesightcrra
+- /materials/Gentle-Intro-to-hark-PerfforesightCRRA
+- /materials/Gentle-Intro-to-hark-Perfforesightcrra
+- /materials/Gentle-Intro-to-hark-perfForesightCRRA
+- /materials/Gentle-Intro-to-hark-perfForesightcrra
+- /materials/Gentle-Intro-to-hark-perfforesightCRRA
+- /materials/Gentle-Intro-to-hark-perfforesightcrra
+- /materials/Gentle-intro-To-HARK-PerfForesightCRRA
+- /materials/Gentle-intro-To-HARK-PerfForesightcrra
+- /materials/Gentle-intro-To-HARK-PerfforesightCRRA
+- /materials/Gentle-intro-To-HARK-Perfforesightcrra
+- /materials/Gentle-intro-To-HARK-perfForesightCRRA
+- /materials/Gentle-intro-To-HARK-perfForesightcrra
+- /materials/Gentle-intro-To-HARK-perfforesightCRRA
+- /materials/Gentle-intro-To-HARK-perfforesightcrra
+- /materials/Gentle-intro-To-hark-PerfForesightCRRA
+- /materials/Gentle-intro-To-hark-PerfForesightcrra
+- /materials/Gentle-intro-To-hark-PerfforesightCRRA
+- /materials/Gentle-intro-To-hark-Perfforesightcrra
+- /materials/Gentle-intro-To-hark-perfForesightCRRA
+- /materials/Gentle-intro-To-hark-perfForesightcrra
+- /materials/Gentle-intro-To-hark-perfforesightCRRA
+- /materials/Gentle-intro-To-hark-perfforesightcrra
+- /materials/Gentle-intro-to-HARK-PerfForesightCRRA
+- /materials/Gentle-intro-to-HARK-PerfForesightcrra
+- /materials/Gentle-intro-to-HARK-PerfforesightCRRA
+- /materials/Gentle-intro-to-HARK-Perfforesightcrra
+- /materials/Gentle-intro-to-HARK-perfForesightCRRA
+- /materials/Gentle-intro-to-HARK-perfForesightcrra
+- /materials/Gentle-intro-to-HARK-perfforesightCRRA
+- /materials/Gentle-intro-to-HARK-perfforesightcrra
+- /materials/Gentle-intro-to-hark-PerfForesightCRRA
+- /materials/Gentle-intro-to-hark-PerfForesightcrra
+- /materials/Gentle-intro-to-hark-PerfforesightCRRA
+- /materials/Gentle-intro-to-hark-Perfforesightcrra
+- /materials/Gentle-intro-to-hark-perfForesightCRRA
+- /materials/Gentle-intro-to-hark-perfForesightcrra
+- /materials/Gentle-intro-to-hark-perfforesightCRRA
+- /materials/Gentle-intro-to-hark-perfforesightcrra
+- /materials/gentle-Intro-To-HARK-PerfForesightCRRA
+- /materials/gentle-Intro-To-HARK-PerfForesightcrra
+- /materials/gentle-Intro-To-HARK-PerfforesightCRRA
+- /materials/gentle-Intro-To-HARK-Perfforesightcrra
+- /materials/gentle-Intro-To-HARK-perfForesightCRRA
+- /materials/gentle-Intro-To-HARK-perfForesightcrra
+- /materials/gentle-Intro-To-HARK-perfforesightCRRA
+- /materials/gentle-Intro-To-HARK-perfforesightcrra
+- /materials/gentle-Intro-To-hark-PerfForesightCRRA
+- /materials/gentle-Intro-To-hark-PerfForesightcrra
+- /materials/gentle-Intro-To-hark-PerfforesightCRRA
+- /materials/gentle-Intro-To-hark-Perfforesightcrra
+- /materials/gentle-Intro-To-hark-perfForesightCRRA
+- /materials/gentle-Intro-To-hark-perfForesightcrra
+- /materials/gentle-Intro-To-hark-perfforesightCRRA
+- /materials/gentle-Intro-To-hark-perfforesightcrra
+- /materials/gentle-Intro-to-HARK-PerfForesightCRRA
+- /materials/gentle-Intro-to-HARK-PerfForesightcrra
+- /materials/gentle-Intro-to-HARK-PerfforesightCRRA
+- /materials/gentle-Intro-to-HARK-Perfforesightcrra
+- /materials/gentle-Intro-to-HARK-perfForesightCRRA
+- /materials/gentle-Intro-to-HARK-perfForesightcrra
+- /materials/gentle-Intro-to-HARK-perfforesightCRRA
+- /materials/gentle-Intro-to-HARK-perfforesightcrra
+- /materials/gentle-Intro-to-hark-PerfForesightCRRA
+- /materials/gentle-Intro-to-hark-PerfForesightcrra
+- /materials/gentle-Intro-to-hark-PerfforesightCRRA
+- /materials/gentle-Intro-to-hark-Perfforesightcrra
+- /materials/gentle-Intro-to-hark-perfForesightCRRA
+- /materials/gentle-Intro-to-hark-perfForesightcrra
+- /materials/gentle-Intro-to-hark-perfforesightCRRA
+- /materials/gentle-Intro-to-hark-perfforesightcrra
+- /materials/gentle-intro-To-HARK-PerfForesightCRRA
+- /materials/gentle-intro-To-HARK-PerfForesightcrra
+- /materials/gentle-intro-To-HARK-PerfforesightCRRA
+- /materials/gentle-intro-To-HARK-Perfforesightcrra
+- /materials/gentle-intro-To-HARK-perfForesightCRRA
+- /materials/gentle-intro-To-HARK-perfForesightcrra
+- /materials/gentle-intro-To-HARK-perfforesightCRRA
+- /materials/gentle-intro-To-HARK-perfforesightcrra
+- /materials/gentle-intro-To-hark-PerfForesightCRRA
+- /materials/gentle-intro-To-hark-PerfForesightcrra
+- /materials/gentle-intro-To-hark-PerfforesightCRRA
+- /materials/gentle-intro-To-hark-Perfforesightcrra
+- /materials/gentle-intro-To-hark-perfForesightCRRA
+- /materials/gentle-intro-To-hark-perfForesightcrra
+- /materials/gentle-intro-To-hark-perfforesightCRRA
+- /materials/gentle-intro-To-hark-perfforesightcrra
+- /materials/gentle-intro-to-HARK-PerfForesightCRRA
+- /materials/gentle-intro-to-HARK-PerfForesightcrra
+- /materials/gentle-intro-to-HARK-PerfforesightCRRA
+- /materials/gentle-intro-to-HARK-Perfforesightcrra
+- /materials/gentle-intro-to-HARK-perfForesightCRRA
+- /materials/gentle-intro-to-HARK-perfForesightcrra
+- /materials/gentle-intro-to-HARK-perfforesightCRRA
+- /materials/gentle-intro-to-HARK-perfforesightcrra
+- /materials/gentle-intro-to-hark-PerfForesightCRRA
+- /materials/gentle-intro-to-hark-PerfForesightcrra
+- /materials/gentle-intro-to-hark-PerfforesightCRRA
+- /materials/gentle-intro-to-hark-Perfforesightcrra
+- /materials/gentle-intro-to-hark-perfForesightCRRA
+- /materials/gentle-intro-to-hark-perfForesightcrra
+- /materials/gentle-intro-to-hark-perfforesightCRRA
+- /materials/gentle-intro-to-hark-perfforesightcrra
 ---
 
 A Gentle Introduction to HARK In Perfect Foresight

--- a/_materials/Gentle-Intro-To-HARK.md
+++ b/_materials/Gentle-Intro-To-HARK.md
@@ -1,23 +1,38 @@
 ---
 name: Gentle-Intro-To-HARK
 tags:
-  - DemARK
-  - Demonstration
-  - Tutorial
-  - Teaching
-  - Notebook
-  - Example
-abstract: 'A Gentle Introduction to HARK for Economists'
+- DemARK
+- Demonstration
+- Tutorial
+- Teaching
+- Notebook
+- Example
+abstract: A Gentle Introduction to HARK for Economists
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/Gentle-Intro/Gentle-Intro-To-HARK.ipynb
-dashboards:
+- examples/Gentle-Intro/Gentle-Intro-To-HARK.ipynb
+dashboards: null
+redirects_from:
+- /materials/Gentle-Intro-To-HARK
+- /materials/Gentle-Intro-To-hark
+- /materials/Gentle-Intro-to-HARK
+- /materials/Gentle-Intro-to-hark
+- /materials/Gentle-intro-To-HARK
+- /materials/Gentle-intro-To-hark
+- /materials/Gentle-intro-to-HARK
+- /materials/Gentle-intro-to-hark
+- /materials/gentle-Intro-To-HARK
+- /materials/gentle-Intro-To-hark
+- /materials/gentle-Intro-to-HARK
+- /materials/gentle-Intro-to-hark
+- /materials/gentle-intro-To-HARK
+- /materials/gentle-intro-To-hark
+- /materials/gentle-intro-to-HARK
+- /materials/gentle-intro-to-hark
 ---
 
 A Gentle Introduction to HARK for Economists

--- a/_materials/Harmenberg-Aggregation.md
+++ b/_materials/Harmenberg-Aggregation.md
@@ -1,35 +1,37 @@
 ---
 name: Harmenberg-Aggregation
 tags:
-  - DemARK
-  - Demonstration
-  - Tutorial
-  - Teaching
-  - Notebook
-abstract: 'Demonstrates that the Harmenberg method speeds up calculations by as much as a factor of 100.'
+- DemARK
+- Demonstration
+- Tutorial
+- Teaching
+- Notebook
+abstract: Demonstrates that the Harmenberg method speeds up calculations by as much
+  as a factor of 100.
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Velásquez-Giraldo"
-    given-names: "Mateo"
-    orcid: "https://orcid.org/0000-0001-7243-6776"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: "Vel\xE1squez-Giraldo"
+  given-names: Mateo
+  orcid: https://orcid.org/0000-0001-7243-6776
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  -
-    notebooks/Harmenberg-Aggregation.ipynb
-dashboards:
-title-original-paper: Aggregating heterogeneous-agent models with permanent income shocks # required for Replications
-identifiers-paper: # required for Replications; optional for Reproductions
-   -
-      type: url
-      value: https://www.sciencedirect.com/science/article/pii/S0165188921001202?via%3Dihub
-   -
-      type: doi
-      value: https://doi.org/10.1016/j.jedc.2021.104185
-date-published-original-paper: 2021-08 # required for Replications; optional for Reproductions
+- notebooks/Harmenberg-Aggregation.ipynb
+dashboards: null
+title-original-paper: Aggregating heterogeneous-agent models with permanent income
+  shocks
+identifiers-paper:
+- type: url
+  value: https://www.sciencedirect.com/science/article/pii/S0165188921001202?via%3Dihub
+- type: doi
+  value: https://doi.org/10.1016/j.jedc.2021.104185
+date-published-original-paper: 2021-08
+redirects_from:
+- /materials/Harmenberg-Aggregation
+- /materials/Harmenberg-aggregation
+- /materials/harmenberg-Aggregation
+- /materials/harmenberg-aggregation
 ---
 
 Harmenberg method for aggregating heterogeneous-agent models with permanent income shocks.

--- a/_materials/IncExpectationExample.md
+++ b/_materials/IncExpectationExample.md
@@ -1,21 +1,28 @@
 ---
 name: IncExpectationExample
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-  - Example
-abstract: 'The Persistent Shock Model and Income Expectations'
+- DemARK
+- Demonstration
+- Notebook
+- Example
+abstract: The Persistent Shock Model and Income Expectations
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/IncExpectationExample.ipynb
-dashboards:
+- notebooks/IncExpectationExample.ipynb
+dashboards: null
+redirects_from:
+- /materials/IncExpectationExample
+- /materials/IncExpectationexample
+- /materials/IncexpectationExample
+- /materials/Incexpectationexample
+- /materials/incExpectationExample
+- /materials/incExpectationexample
+- /materials/incexpectationExample
+- /materials/incexpectationexample
 ---
 
 The Persistent Shock Model and Income Expectations

--- a/_materials/IndShockConsumerType.md
+++ b/_materials/IndShockConsumerType.md
@@ -1,22 +1,37 @@
 ---
 name: IndShockConsumerType
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'IndShockConsumerType Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: IndShockConsumerType Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsIndShockModel/IndShockConsumerType.ipynb
-dashboards:
+- examples/ConsIndShockModel/IndShockConsumerType.ipynb
+dashboards: null
+redirects_from:
+- /materials/IndShockConsumerType
+- /materials/IndShockConsumertype
+- /materials/IndShockconsumerType
+- /materials/IndShockconsumertype
+- /materials/IndshockConsumerType
+- /materials/IndshockConsumertype
+- /materials/IndshockconsumerType
+- /materials/Indshockconsumertype
+- /materials/indShockConsumerType
+- /materials/indShockConsumertype
+- /materials/indShockconsumerType
+- /materials/indShockconsumertype
+- /materials/indshockConsumerType
+- /materials/indshockConsumertype
+- /materials/indshockconsumerType
+- /materials/indshockconsumertype
 ---
 
 Detailed description of the `IndShockConsumerType` class

--- a/_materials/KeynesFriedmanModigliani.md
+++ b/_materials/KeynesFriedmanModigliani.md
@@ -1,21 +1,28 @@
 ---
 name: KeynesFriedmanModigliani
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
 abstract: 'Introduction: Keynes, Friedman, Modigliani'
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/KeynesFriedmanModigliani.ipynb
-dashboards:
+- notebooks/KeynesFriedmanModigliani.ipynb
+dashboards: null
+redirects_from:
+- /materials/KeynesFriedmanModigliani
+- /materials/KeynesFriedmanmodigliani
+- /materials/KeynesfriedmanModigliani
+- /materials/Keynesfriedmanmodigliani
+- /materials/keynesFriedmanModigliani
+- /materials/keynesFriedmanmodigliani
+- /materials/keynesfriedmanModigliani
+- /materials/keynesfriedmanmodigliani
 ---
 
 Introduction: Keynes, Friedman, Modigliani

--- a/_materials/KinkedRconsumerType.md
+++ b/_materials/KinkedRconsumerType.md
@@ -1,22 +1,29 @@
 ---
 name: KinkedRconsumerType
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'KinkedRconsumerType Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: KinkedRconsumerType Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsIndShockModel/KinkedRconsumerType.ipynb
-dashboards:
+- examples/ConsIndShockModel/KinkedRconsumerType.ipynb
+dashboards: null
+redirects_from:
+- /materials/KinkedRconsumerType
+- /materials/KinkedRconsumertype
+- /materials/KinkedrconsumerType
+- /materials/Kinkedrconsumertype
+- /materials/kinkedRconsumerType
+- /materials/kinkedRconsumertype
+- /materials/kinkedrconsumerType
+- /materials/kinkedrconsumertype
 ---
 
 Detailed description of the `KinkedRconsumerType` class

--- a/_materials/KrusellSmith.md
+++ b/_materials/KrusellSmith.md
@@ -1,42 +1,35 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required (don't change)
-authors: # required
-  - family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-title: "KrusellSmith" # required
-abstract: "Income and wealth heterogeneity in the macroeconomy" # optional
-
-# REMARK required fields
-remark-version: "1.0" # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Krusell"
-        given-names: "Per"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Smith, Jr."
-        given-names: "Anthony A."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Income and Wealth Heterogeneity in the Macroeconomy" # required
-    doi: "https://doi.org/10.1086/250034" # optional
-    date: 1998-10 # required
-    publisher: "Journal of Political Economy"
-
-# Econ-ARK website fields
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+title: KrusellSmith
+abstract: Income and wealth heterogeneity in the macroeconomy
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Krusell
+    given-names: Per
+  - family-names: Smith, Jr.
+    given-names: Anthony A.
+  title: Income and Wealth Heterogeneity in the Macroeconomy
+  doi: https://doi.org/10.1086/250034
+  date: 1998-10
+  publisher: Journal of Political Economy
 github_repo_url: https://github.com/econ-ark/KrusellSmith
-remark-name: KrusellSmith # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    Code/Python/KrusellSmith.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Notebook
-
+remark-name: KrusellSmith
+notebooks:
+- Code/Python/KrusellSmith.ipynb
+tags:
+- REMARK
+- Notebook
+redirects_from:
+- /materials/KrusellSmith
+- /materials/Krusellsmith
+- /materials/krusellSmith
+- /materials/krusellsmith
 ---
 
 

--- a/_materials/LC-Model-Expected-Vs-Realized-Income-Growth.md
+++ b/_materials/LC-Model-Expected-Vs-Realized-Income-Growth.md
@@ -1,20 +1,148 @@
 ---
 name: LC-Model-Expected-Vs-Realized-Income-Growth
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'This notebook examines the relationship between expected and actual income growth in a model with transitory and permanent shocks'
+- DemARK
+- Demonstration
+- Notebook
+abstract: This notebook examines the relationship between expected and actual income
+  growth in a model with transitory and permanent shocks
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/LC-Model-Expected-Vs-Realized-Income-Growth.ipynb
-dashboards:
+- notebooks/LC-Model-Expected-Vs-Realized-Income-Growth.ipynb
+dashboards: null
+redirects_from:
+- /materials/LC-Model-Expected-Vs-Realized-Income-Growth
+- /materials/LC-Model-Expected-Vs-Realized-Income-growth
+- /materials/LC-Model-Expected-Vs-Realized-income-Growth
+- /materials/LC-Model-Expected-Vs-Realized-income-growth
+- /materials/LC-Model-Expected-Vs-realized-Income-Growth
+- /materials/LC-Model-Expected-Vs-realized-Income-growth
+- /materials/LC-Model-Expected-Vs-realized-income-Growth
+- /materials/LC-Model-Expected-Vs-realized-income-growth
+- /materials/LC-Model-Expected-vs-Realized-Income-Growth
+- /materials/LC-Model-Expected-vs-Realized-Income-growth
+- /materials/LC-Model-Expected-vs-Realized-income-Growth
+- /materials/LC-Model-Expected-vs-Realized-income-growth
+- /materials/LC-Model-Expected-vs-realized-Income-Growth
+- /materials/LC-Model-Expected-vs-realized-Income-growth
+- /materials/LC-Model-Expected-vs-realized-income-Growth
+- /materials/LC-Model-Expected-vs-realized-income-growth
+- /materials/LC-Model-expected-Vs-Realized-Income-Growth
+- /materials/LC-Model-expected-Vs-Realized-Income-growth
+- /materials/LC-Model-expected-Vs-Realized-income-Growth
+- /materials/LC-Model-expected-Vs-Realized-income-growth
+- /materials/LC-Model-expected-Vs-realized-Income-Growth
+- /materials/LC-Model-expected-Vs-realized-Income-growth
+- /materials/LC-Model-expected-Vs-realized-income-Growth
+- /materials/LC-Model-expected-Vs-realized-income-growth
+- /materials/LC-Model-expected-vs-Realized-Income-Growth
+- /materials/LC-Model-expected-vs-Realized-Income-growth
+- /materials/LC-Model-expected-vs-Realized-income-Growth
+- /materials/LC-Model-expected-vs-Realized-income-growth
+- /materials/LC-Model-expected-vs-realized-Income-Growth
+- /materials/LC-Model-expected-vs-realized-Income-growth
+- /materials/LC-Model-expected-vs-realized-income-Growth
+- /materials/LC-Model-expected-vs-realized-income-growth
+- /materials/LC-model-Expected-Vs-Realized-Income-Growth
+- /materials/LC-model-Expected-Vs-Realized-Income-growth
+- /materials/LC-model-Expected-Vs-Realized-income-Growth
+- /materials/LC-model-Expected-Vs-Realized-income-growth
+- /materials/LC-model-Expected-Vs-realized-Income-Growth
+- /materials/LC-model-Expected-Vs-realized-Income-growth
+- /materials/LC-model-Expected-Vs-realized-income-Growth
+- /materials/LC-model-Expected-Vs-realized-income-growth
+- /materials/LC-model-Expected-vs-Realized-Income-Growth
+- /materials/LC-model-Expected-vs-Realized-Income-growth
+- /materials/LC-model-Expected-vs-Realized-income-Growth
+- /materials/LC-model-Expected-vs-Realized-income-growth
+- /materials/LC-model-Expected-vs-realized-Income-Growth
+- /materials/LC-model-Expected-vs-realized-Income-growth
+- /materials/LC-model-Expected-vs-realized-income-Growth
+- /materials/LC-model-Expected-vs-realized-income-growth
+- /materials/LC-model-expected-Vs-Realized-Income-Growth
+- /materials/LC-model-expected-Vs-Realized-Income-growth
+- /materials/LC-model-expected-Vs-Realized-income-Growth
+- /materials/LC-model-expected-Vs-Realized-income-growth
+- /materials/LC-model-expected-Vs-realized-Income-Growth
+- /materials/LC-model-expected-Vs-realized-Income-growth
+- /materials/LC-model-expected-Vs-realized-income-Growth
+- /materials/LC-model-expected-Vs-realized-income-growth
+- /materials/LC-model-expected-vs-Realized-Income-Growth
+- /materials/LC-model-expected-vs-Realized-Income-growth
+- /materials/LC-model-expected-vs-Realized-income-Growth
+- /materials/LC-model-expected-vs-Realized-income-growth
+- /materials/LC-model-expected-vs-realized-Income-Growth
+- /materials/LC-model-expected-vs-realized-Income-growth
+- /materials/LC-model-expected-vs-realized-income-Growth
+- /materials/LC-model-expected-vs-realized-income-growth
+- /materials/lc-Model-Expected-Vs-Realized-Income-Growth
+- /materials/lc-Model-Expected-Vs-Realized-Income-growth
+- /materials/lc-Model-Expected-Vs-Realized-income-Growth
+- /materials/lc-Model-Expected-Vs-Realized-income-growth
+- /materials/lc-Model-Expected-Vs-realized-Income-Growth
+- /materials/lc-Model-Expected-Vs-realized-Income-growth
+- /materials/lc-Model-Expected-Vs-realized-income-Growth
+- /materials/lc-Model-Expected-Vs-realized-income-growth
+- /materials/lc-Model-Expected-vs-Realized-Income-Growth
+- /materials/lc-Model-Expected-vs-Realized-Income-growth
+- /materials/lc-Model-Expected-vs-Realized-income-Growth
+- /materials/lc-Model-Expected-vs-Realized-income-growth
+- /materials/lc-Model-Expected-vs-realized-Income-Growth
+- /materials/lc-Model-Expected-vs-realized-Income-growth
+- /materials/lc-Model-Expected-vs-realized-income-Growth
+- /materials/lc-Model-Expected-vs-realized-income-growth
+- /materials/lc-Model-expected-Vs-Realized-Income-Growth
+- /materials/lc-Model-expected-Vs-Realized-Income-growth
+- /materials/lc-Model-expected-Vs-Realized-income-Growth
+- /materials/lc-Model-expected-Vs-Realized-income-growth
+- /materials/lc-Model-expected-Vs-realized-Income-Growth
+- /materials/lc-Model-expected-Vs-realized-Income-growth
+- /materials/lc-Model-expected-Vs-realized-income-Growth
+- /materials/lc-Model-expected-Vs-realized-income-growth
+- /materials/lc-Model-expected-vs-Realized-Income-Growth
+- /materials/lc-Model-expected-vs-Realized-Income-growth
+- /materials/lc-Model-expected-vs-Realized-income-Growth
+- /materials/lc-Model-expected-vs-Realized-income-growth
+- /materials/lc-Model-expected-vs-realized-Income-Growth
+- /materials/lc-Model-expected-vs-realized-Income-growth
+- /materials/lc-Model-expected-vs-realized-income-Growth
+- /materials/lc-Model-expected-vs-realized-income-growth
+- /materials/lc-model-Expected-Vs-Realized-Income-Growth
+- /materials/lc-model-Expected-Vs-Realized-Income-growth
+- /materials/lc-model-Expected-Vs-Realized-income-Growth
+- /materials/lc-model-Expected-Vs-Realized-income-growth
+- /materials/lc-model-Expected-Vs-realized-Income-Growth
+- /materials/lc-model-Expected-Vs-realized-Income-growth
+- /materials/lc-model-Expected-Vs-realized-income-Growth
+- /materials/lc-model-Expected-Vs-realized-income-growth
+- /materials/lc-model-Expected-vs-Realized-Income-Growth
+- /materials/lc-model-Expected-vs-Realized-Income-growth
+- /materials/lc-model-Expected-vs-Realized-income-Growth
+- /materials/lc-model-Expected-vs-Realized-income-growth
+- /materials/lc-model-Expected-vs-realized-Income-Growth
+- /materials/lc-model-Expected-vs-realized-Income-growth
+- /materials/lc-model-Expected-vs-realized-income-Growth
+- /materials/lc-model-Expected-vs-realized-income-growth
+- /materials/lc-model-expected-Vs-Realized-Income-Growth
+- /materials/lc-model-expected-Vs-Realized-Income-growth
+- /materials/lc-model-expected-Vs-Realized-income-Growth
+- /materials/lc-model-expected-Vs-Realized-income-growth
+- /materials/lc-model-expected-Vs-realized-Income-Growth
+- /materials/lc-model-expected-Vs-realized-Income-growth
+- /materials/lc-model-expected-Vs-realized-income-Growth
+- /materials/lc-model-expected-Vs-realized-income-growth
+- /materials/lc-model-expected-vs-Realized-Income-Growth
+- /materials/lc-model-expected-vs-Realized-Income-growth
+- /materials/lc-model-expected-vs-Realized-income-Growth
+- /materials/lc-model-expected-vs-Realized-income-growth
+- /materials/lc-model-expected-vs-realized-Income-Growth
+- /materials/lc-model-expected-vs-realized-Income-growth
+- /materials/lc-model-expected-vs-realized-income-Growth
+- /materials/lc-model-expected-vs-realized-income-growth
 ---
 
 Expected Versus Realized Income Growth in a Life Cycle Model with transitory and permanent shocks to income

--- a/_materials/LifeCycleModelTheoryVsData.md
+++ b/_materials/LifeCycleModelTheoryVsData.md
@@ -1,20 +1,83 @@
 ---
 name: LifeCycleModelTheoryVsData
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
+- DemARK
+- Demonstration
+- Notebook
 abstract: 'The Life Cycle Model: Theory vs Data'
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/LifeCycleModelTheoryVsData.ipynb
-dashboards:
+- notebooks/LifeCycleModelTheoryVsData.ipynb
+dashboards: null
+redirects_from:
+- /materials/LifeCycleModelTheoryVsData
+- /materials/LifeCycleModelTheoryVsdata
+- /materials/LifeCycleModelTheoryvsData
+- /materials/LifeCycleModelTheoryvsdata
+- /materials/LifeCycleModeltheoryVsData
+- /materials/LifeCycleModeltheoryVsdata
+- /materials/LifeCycleModeltheoryvsData
+- /materials/LifeCycleModeltheoryvsdata
+- /materials/LifeCyclemodelTheoryVsData
+- /materials/LifeCyclemodelTheoryVsdata
+- /materials/LifeCyclemodelTheoryvsData
+- /materials/LifeCyclemodelTheoryvsdata
+- /materials/LifeCyclemodeltheoryVsData
+- /materials/LifeCyclemodeltheoryVsdata
+- /materials/LifeCyclemodeltheoryvsData
+- /materials/LifeCyclemodeltheoryvsdata
+- /materials/LifecycleModelTheoryVsData
+- /materials/LifecycleModelTheoryVsdata
+- /materials/LifecycleModelTheoryvsData
+- /materials/LifecycleModelTheoryvsdata
+- /materials/LifecycleModeltheoryVsData
+- /materials/LifecycleModeltheoryVsdata
+- /materials/LifecycleModeltheoryvsData
+- /materials/LifecycleModeltheoryvsdata
+- /materials/LifecyclemodelTheoryVsData
+- /materials/LifecyclemodelTheoryVsdata
+- /materials/LifecyclemodelTheoryvsData
+- /materials/LifecyclemodelTheoryvsdata
+- /materials/LifecyclemodeltheoryVsData
+- /materials/LifecyclemodeltheoryVsdata
+- /materials/LifecyclemodeltheoryvsData
+- /materials/Lifecyclemodeltheoryvsdata
+- /materials/lifeCycleModelTheoryVsData
+- /materials/lifeCycleModelTheoryVsdata
+- /materials/lifeCycleModelTheoryvsData
+- /materials/lifeCycleModelTheoryvsdata
+- /materials/lifeCycleModeltheoryVsData
+- /materials/lifeCycleModeltheoryVsdata
+- /materials/lifeCycleModeltheoryvsData
+- /materials/lifeCycleModeltheoryvsdata
+- /materials/lifeCyclemodelTheoryVsData
+- /materials/lifeCyclemodelTheoryVsdata
+- /materials/lifeCyclemodelTheoryvsData
+- /materials/lifeCyclemodelTheoryvsdata
+- /materials/lifeCyclemodeltheoryVsData
+- /materials/lifeCyclemodeltheoryVsdata
+- /materials/lifeCyclemodeltheoryvsData
+- /materials/lifeCyclemodeltheoryvsdata
+- /materials/lifecycleModelTheoryVsData
+- /materials/lifecycleModelTheoryVsdata
+- /materials/lifecycleModelTheoryvsData
+- /materials/lifecycleModelTheoryvsdata
+- /materials/lifecycleModeltheoryVsData
+- /materials/lifecycleModeltheoryVsdata
+- /materials/lifecycleModeltheoryvsData
+- /materials/lifecycleModeltheoryvsdata
+- /materials/lifecyclemodelTheoryVsData
+- /materials/lifecyclemodelTheoryVsdata
+- /materials/lifecyclemodelTheoryvsData
+- /materials/lifecyclemodelTheoryvsdata
+- /materials/lifecyclemodeltheoryVsData
+- /materials/lifecyclemodeltheoryVsdata
+- /materials/lifecyclemodeltheoryvsData
+- /materials/lifecyclemodeltheoryvsdata
 ---
 
 The Life Cycle Model: Theory vs Data

--- a/_materials/LiqConstr.md
+++ b/_materials/LiqConstr.md
@@ -1,64 +1,61 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required 
-message: "This paper shows that liquidity constraints and precautionary saving are closely related to each other, since both can be thought of is \"counterclockwise concavifications\" of the consumption function.; all results are paired with illustrative numerical solutions." # required
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Kimball"
-    given-names: "Miles S."
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "Holm"
-    given-names: "Martin B."
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: "Liquidity Constraints and Precautionary Saving" # required
-abstract: "We provide the analytical explanation of strong interactions between precautionary sav- ing and liquidity constraints that are regularly observed in numerical solutions to consump- tion/saving models. The effects of constraints and of uncertainty spring from the same cause: concavification of the consumption function, which can be induced either by constraints or by uncertainty. Concavification propagates back to consumption functions in prior periods. But, surprisingly, once a linear consumption function has been concavified by the presence of either risks or constraints, the introduction of additional concavifiers in a given period can reduce the precautionary motive in earlier periods at some levels of wealth." # abstract: optional
-date-released: 2020-09-14 # required
-
-# REMARK required fields
-remark-version: "1.0" # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Kimball"
-        given-names: "Miles S."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Holm"
-        given-names: "Martin B."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Liquidity Constraints and Precautionary Savings" # required
-    doi: "https://doi.org/10.1016/j.jet.2021.105276" # optional
-    date: 2021-07 # required
-    publisher: "Journal of Economic Theory" #optional
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/llorracc/LiqConstr # required 
-remark-name: LiqConstr # required 
-notebooks: # path to any notebooks within the repo - optional
-  - 
-    LiqConstr.ipynb
-dashboards: # path to any dahsboards within the repo - optional
-  - 
-    LiqConstr-Dashboard.ipynb
-tags: # Use the relavent tags
-  - REMARK
-  - Reproduction
-
-keywords: # optional
-  - liquidity constraints
-  - uncertainty
-  - precautionary saving
-
+cff-version: 1.1.0
+message: This paper shows that liquidity constraints and precautionary saving are
+  closely related to each other, since both can be thought of is "counterclockwise
+  concavifications" of the consumption function.; all results are paired with illustrative
+  numerical solutions.
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Kimball
+  given-names: Miles S.
+- family-names: Holm
+  given-names: Martin B.
+title: Liquidity Constraints and Precautionary Saving
+abstract: 'We provide the analytical explanation of strong interactions between precautionary
+  sav- ing and liquidity constraints that are regularly observed in numerical solutions
+  to consump- tion/saving models. The effects of constraints and of uncertainty spring
+  from the same cause: concavification of the consumption function, which can be induced
+  either by constraints or by uncertainty. Concavification propagates back to consumption
+  functions in prior periods. But, surprisingly, once a linear consumption function
+  has been concavified by the presence of either risks or constraints, the introduction
+  of additional concavifiers in a given period can reduce the precautionary motive
+  in earlier periods at some levels of wealth.'
+date-released: 2020-09-14
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Kimball
+    given-names: Miles S.
+  - family-names: Holm
+    given-names: Martin B.
+  title: Liquidity Constraints and Precautionary Savings
+  doi: https://doi.org/10.1016/j.jet.2021.105276
+  date: 2021-07
+  publisher: Journal of Economic Theory
+github_repo_url: https://github.com/llorracc/LiqConstr
+remark-name: LiqConstr
+notebooks:
+- LiqConstr.ipynb
+dashboards:
+- LiqConstr-Dashboard.ipynb
+tags:
+- REMARK
+- Reproduction
+keywords:
+- liquidity constraints
+- uncertainty
+- precautionary saving
+redirects_from:
+- /materials/LiqConstr
+- /materials/Liqconstr
+- /materials/liqConstr
+- /materials/liqconstr
 ---
 
 # Liquidity Constraints and Precautionary Saving

--- a/_materials/Lucas-Asset-Pricing-Model.md
+++ b/_materials/Lucas-Asset-Pricing-Model.md
@@ -1,26 +1,38 @@
 ---
 name: Lucas-Asset-Pricing-Model
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
-abstract: 'A demonstration of the Lucas Asset-Pricing model'
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
+abstract: A demonstration of the Lucas Asset-Pricing model
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-
-  -
-    family-names: "Velásquez-Giraldo"
-    given-names: "Mateo"
-    orcid: "https://orcid.org/0000-0001-7243-6776"
-
-date-released:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: "Vel\xE1squez-Giraldo"
+  given-names: Mateo
+  orcid: https://orcid.org/0000-0001-7243-6776
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  -
-    notebooks/Lucas-Asset-Pricing-Model.ipynb
-dashboards:
+- notebooks/Lucas-Asset-Pricing-Model.ipynb
+dashboards: null
+redirects_from:
+- /materials/Lucas-Asset-Pricing-Model
+- /materials/Lucas-Asset-Pricing-model
+- /materials/Lucas-Asset-pricing-Model
+- /materials/Lucas-Asset-pricing-model
+- /materials/Lucas-asset-Pricing-Model
+- /materials/Lucas-asset-Pricing-model
+- /materials/Lucas-asset-pricing-Model
+- /materials/Lucas-asset-pricing-model
+- /materials/lucas-Asset-Pricing-Model
+- /materials/lucas-Asset-Pricing-model
+- /materials/lucas-Asset-pricing-Model
+- /materials/lucas-Asset-pricing-model
+- /materials/lucas-asset-Pricing-Model
+- /materials/lucas-asset-Pricing-model
+- /materials/lucas-asset-pricing-Model
+- /materials/lucas-asset-pricing-model
 ---

--- a/_materials/MPC-Out-of-Credit-vs-MPC-Out-of-Income.md
+++ b/_materials/MPC-Out-of-Credit-vs-MPC-Out-of-Income.md
@@ -1,20 +1,83 @@
 ---
 name: MPC-Out-of-Credit-vs-MPC-Out-of-Income
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'The MPC out of Credit vs the MPC Out of Income'
+- DemARK
+- Demonstration
+- Notebook
+abstract: The MPC out of Credit vs the MPC Out of Income
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/MPC-Out-of-Credit-vs-MPC-Out-of-Income.ipynb
-dashboards:
+- notebooks/MPC-Out-of-Credit-vs-MPC-Out-of-Income.ipynb
+dashboards: null
+redirects_from:
+- /materials/MPC-Out-of-Credit-vs-MPC-Out-of-Income
+- /materials/MPC-Out-of-Credit-vs-MPC-Out-of-income
+- /materials/MPC-Out-of-Credit-vs-MPC-out-of-Income
+- /materials/MPC-Out-of-Credit-vs-MPC-out-of-income
+- /materials/MPC-Out-of-Credit-vs-mpc-Out-of-Income
+- /materials/MPC-Out-of-Credit-vs-mpc-Out-of-income
+- /materials/MPC-Out-of-Credit-vs-mpc-out-of-Income
+- /materials/MPC-Out-of-Credit-vs-mpc-out-of-income
+- /materials/MPC-Out-of-credit-vs-MPC-Out-of-Income
+- /materials/MPC-Out-of-credit-vs-MPC-Out-of-income
+- /materials/MPC-Out-of-credit-vs-MPC-out-of-Income
+- /materials/MPC-Out-of-credit-vs-MPC-out-of-income
+- /materials/MPC-Out-of-credit-vs-mpc-Out-of-Income
+- /materials/MPC-Out-of-credit-vs-mpc-Out-of-income
+- /materials/MPC-Out-of-credit-vs-mpc-out-of-Income
+- /materials/MPC-Out-of-credit-vs-mpc-out-of-income
+- /materials/MPC-out-of-Credit-vs-MPC-Out-of-Income
+- /materials/MPC-out-of-Credit-vs-MPC-Out-of-income
+- /materials/MPC-out-of-Credit-vs-MPC-out-of-Income
+- /materials/MPC-out-of-Credit-vs-MPC-out-of-income
+- /materials/MPC-out-of-Credit-vs-mpc-Out-of-Income
+- /materials/MPC-out-of-Credit-vs-mpc-Out-of-income
+- /materials/MPC-out-of-Credit-vs-mpc-out-of-Income
+- /materials/MPC-out-of-Credit-vs-mpc-out-of-income
+- /materials/MPC-out-of-credit-vs-MPC-Out-of-Income
+- /materials/MPC-out-of-credit-vs-MPC-Out-of-income
+- /materials/MPC-out-of-credit-vs-MPC-out-of-Income
+- /materials/MPC-out-of-credit-vs-MPC-out-of-income
+- /materials/MPC-out-of-credit-vs-mpc-Out-of-Income
+- /materials/MPC-out-of-credit-vs-mpc-Out-of-income
+- /materials/MPC-out-of-credit-vs-mpc-out-of-Income
+- /materials/MPC-out-of-credit-vs-mpc-out-of-income
+- /materials/mpc-Out-of-Credit-vs-MPC-Out-of-Income
+- /materials/mpc-Out-of-Credit-vs-MPC-Out-of-income
+- /materials/mpc-Out-of-Credit-vs-MPC-out-of-Income
+- /materials/mpc-Out-of-Credit-vs-MPC-out-of-income
+- /materials/mpc-Out-of-Credit-vs-mpc-Out-of-Income
+- /materials/mpc-Out-of-Credit-vs-mpc-Out-of-income
+- /materials/mpc-Out-of-Credit-vs-mpc-out-of-Income
+- /materials/mpc-Out-of-Credit-vs-mpc-out-of-income
+- /materials/mpc-Out-of-credit-vs-MPC-Out-of-Income
+- /materials/mpc-Out-of-credit-vs-MPC-Out-of-income
+- /materials/mpc-Out-of-credit-vs-MPC-out-of-Income
+- /materials/mpc-Out-of-credit-vs-MPC-out-of-income
+- /materials/mpc-Out-of-credit-vs-mpc-Out-of-Income
+- /materials/mpc-Out-of-credit-vs-mpc-Out-of-income
+- /materials/mpc-Out-of-credit-vs-mpc-out-of-Income
+- /materials/mpc-Out-of-credit-vs-mpc-out-of-income
+- /materials/mpc-out-of-Credit-vs-MPC-Out-of-Income
+- /materials/mpc-out-of-Credit-vs-MPC-Out-of-income
+- /materials/mpc-out-of-Credit-vs-MPC-out-of-Income
+- /materials/mpc-out-of-Credit-vs-MPC-out-of-income
+- /materials/mpc-out-of-Credit-vs-mpc-Out-of-Income
+- /materials/mpc-out-of-Credit-vs-mpc-Out-of-income
+- /materials/mpc-out-of-Credit-vs-mpc-out-of-Income
+- /materials/mpc-out-of-Credit-vs-mpc-out-of-income
+- /materials/mpc-out-of-credit-vs-MPC-Out-of-Income
+- /materials/mpc-out-of-credit-vs-MPC-Out-of-income
+- /materials/mpc-out-of-credit-vs-MPC-out-of-Income
+- /materials/mpc-out-of-credit-vs-MPC-out-of-income
+- /materials/mpc-out-of-credit-vs-mpc-Out-of-Income
+- /materials/mpc-out-of-credit-vs-mpc-Out-of-income
+- /materials/mpc-out-of-credit-vs-mpc-out-of-Income
+- /materials/mpc-out-of-credit-vs-mpc-out-of-income
 ---
 
 The MPC out of Credit vs the MPC Out of Income

--- a/_materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs-Problems.md
+++ b/_materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs-Problems.md
@@ -1,21 +1,148 @@
 ---
 name: Micro-and-Macro-Implications-of-Very-Impatient-HHs
 tags:
-  - QuARK
-  - Demonstration
-  - Notebook
-  - Teaching
-abstract: 'Micro- and Macroeconomic Implications of Very Impatient Households'
+- QuARK
+- Demonstration
+- Notebook
+- Teaching
+abstract: Micro- and Macroeconomic Implications of Very Impatient Households
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/QuARK
 notebooks:
-  - 
-    notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
-dashboards:
+- notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
+dashboards: null
+redirects_from:
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs-Problems
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs-problems
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-hhs-Problems
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-hhs-problems
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-HHs-Problems
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-HHs-problems
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-hhs-Problems
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-hhs-problems
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-HHs-Problems
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-HHs-problems
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-hhs-Problems
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-hhs-problems
+- /materials/Micro-and-Macro-Implications-of-very-impatient-HHs-Problems
+- /materials/Micro-and-Macro-Implications-of-very-impatient-HHs-problems
+- /materials/Micro-and-Macro-Implications-of-very-impatient-hhs-Problems
+- /materials/Micro-and-Macro-Implications-of-very-impatient-hhs-problems
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-HHs-Problems
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-HHs-problems
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-hhs-Problems
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-hhs-problems
+- /materials/Micro-and-Macro-implications-of-Very-impatient-HHs-Problems
+- /materials/Micro-and-Macro-implications-of-Very-impatient-HHs-problems
+- /materials/Micro-and-Macro-implications-of-Very-impatient-hhs-Problems
+- /materials/Micro-and-Macro-implications-of-Very-impatient-hhs-problems
+- /materials/Micro-and-Macro-implications-of-very-Impatient-HHs-Problems
+- /materials/Micro-and-Macro-implications-of-very-Impatient-HHs-problems
+- /materials/Micro-and-Macro-implications-of-very-Impatient-hhs-Problems
+- /materials/Micro-and-Macro-implications-of-very-Impatient-hhs-problems
+- /materials/Micro-and-Macro-implications-of-very-impatient-HHs-Problems
+- /materials/Micro-and-Macro-implications-of-very-impatient-HHs-problems
+- /materials/Micro-and-Macro-implications-of-very-impatient-hhs-Problems
+- /materials/Micro-and-Macro-implications-of-very-impatient-hhs-problems
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-HHs-Problems
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-HHs-problems
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-hhs-Problems
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-hhs-problems
+- /materials/Micro-and-macro-Implications-of-Very-impatient-HHs-Problems
+- /materials/Micro-and-macro-Implications-of-Very-impatient-HHs-problems
+- /materials/Micro-and-macro-Implications-of-Very-impatient-hhs-Problems
+- /materials/Micro-and-macro-Implications-of-Very-impatient-hhs-problems
+- /materials/Micro-and-macro-Implications-of-very-Impatient-HHs-Problems
+- /materials/Micro-and-macro-Implications-of-very-Impatient-HHs-problems
+- /materials/Micro-and-macro-Implications-of-very-Impatient-hhs-Problems
+- /materials/Micro-and-macro-Implications-of-very-Impatient-hhs-problems
+- /materials/Micro-and-macro-Implications-of-very-impatient-HHs-Problems
+- /materials/Micro-and-macro-Implications-of-very-impatient-HHs-problems
+- /materials/Micro-and-macro-Implications-of-very-impatient-hhs-Problems
+- /materials/Micro-and-macro-Implications-of-very-impatient-hhs-problems
+- /materials/Micro-and-macro-implications-of-Very-Impatient-HHs-Problems
+- /materials/Micro-and-macro-implications-of-Very-Impatient-HHs-problems
+- /materials/Micro-and-macro-implications-of-Very-Impatient-hhs-Problems
+- /materials/Micro-and-macro-implications-of-Very-Impatient-hhs-problems
+- /materials/Micro-and-macro-implications-of-Very-impatient-HHs-Problems
+- /materials/Micro-and-macro-implications-of-Very-impatient-HHs-problems
+- /materials/Micro-and-macro-implications-of-Very-impatient-hhs-Problems
+- /materials/Micro-and-macro-implications-of-Very-impatient-hhs-problems
+- /materials/Micro-and-macro-implications-of-very-Impatient-HHs-Problems
+- /materials/Micro-and-macro-implications-of-very-Impatient-HHs-problems
+- /materials/Micro-and-macro-implications-of-very-Impatient-hhs-Problems
+- /materials/Micro-and-macro-implications-of-very-Impatient-hhs-problems
+- /materials/Micro-and-macro-implications-of-very-impatient-HHs-Problems
+- /materials/Micro-and-macro-implications-of-very-impatient-HHs-problems
+- /materials/Micro-and-macro-implications-of-very-impatient-hhs-Problems
+- /materials/Micro-and-macro-implications-of-very-impatient-hhs-problems
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-HHs-Problems
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-HHs-problems
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-hhs-Problems
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-hhs-problems
+- /materials/micro-and-Macro-Implications-of-Very-impatient-HHs-Problems
+- /materials/micro-and-Macro-Implications-of-Very-impatient-HHs-problems
+- /materials/micro-and-Macro-Implications-of-Very-impatient-hhs-Problems
+- /materials/micro-and-Macro-Implications-of-Very-impatient-hhs-problems
+- /materials/micro-and-Macro-Implications-of-very-Impatient-HHs-Problems
+- /materials/micro-and-Macro-Implications-of-very-Impatient-HHs-problems
+- /materials/micro-and-Macro-Implications-of-very-Impatient-hhs-Problems
+- /materials/micro-and-Macro-Implications-of-very-Impatient-hhs-problems
+- /materials/micro-and-Macro-Implications-of-very-impatient-HHs-Problems
+- /materials/micro-and-Macro-Implications-of-very-impatient-HHs-problems
+- /materials/micro-and-Macro-Implications-of-very-impatient-hhs-Problems
+- /materials/micro-and-Macro-Implications-of-very-impatient-hhs-problems
+- /materials/micro-and-Macro-implications-of-Very-Impatient-HHs-Problems
+- /materials/micro-and-Macro-implications-of-Very-Impatient-HHs-problems
+- /materials/micro-and-Macro-implications-of-Very-Impatient-hhs-Problems
+- /materials/micro-and-Macro-implications-of-Very-Impatient-hhs-problems
+- /materials/micro-and-Macro-implications-of-Very-impatient-HHs-Problems
+- /materials/micro-and-Macro-implications-of-Very-impatient-HHs-problems
+- /materials/micro-and-Macro-implications-of-Very-impatient-hhs-Problems
+- /materials/micro-and-Macro-implications-of-Very-impatient-hhs-problems
+- /materials/micro-and-Macro-implications-of-very-Impatient-HHs-Problems
+- /materials/micro-and-Macro-implications-of-very-Impatient-HHs-problems
+- /materials/micro-and-Macro-implications-of-very-Impatient-hhs-Problems
+- /materials/micro-and-Macro-implications-of-very-Impatient-hhs-problems
+- /materials/micro-and-Macro-implications-of-very-impatient-HHs-Problems
+- /materials/micro-and-Macro-implications-of-very-impatient-HHs-problems
+- /materials/micro-and-Macro-implications-of-very-impatient-hhs-Problems
+- /materials/micro-and-Macro-implications-of-very-impatient-hhs-problems
+- /materials/micro-and-macro-Implications-of-Very-Impatient-HHs-Problems
+- /materials/micro-and-macro-Implications-of-Very-Impatient-HHs-problems
+- /materials/micro-and-macro-Implications-of-Very-Impatient-hhs-Problems
+- /materials/micro-and-macro-Implications-of-Very-Impatient-hhs-problems
+- /materials/micro-and-macro-Implications-of-Very-impatient-HHs-Problems
+- /materials/micro-and-macro-Implications-of-Very-impatient-HHs-problems
+- /materials/micro-and-macro-Implications-of-Very-impatient-hhs-Problems
+- /materials/micro-and-macro-Implications-of-Very-impatient-hhs-problems
+- /materials/micro-and-macro-Implications-of-very-Impatient-HHs-Problems
+- /materials/micro-and-macro-Implications-of-very-Impatient-HHs-problems
+- /materials/micro-and-macro-Implications-of-very-Impatient-hhs-Problems
+- /materials/micro-and-macro-Implications-of-very-Impatient-hhs-problems
+- /materials/micro-and-macro-Implications-of-very-impatient-HHs-Problems
+- /materials/micro-and-macro-Implications-of-very-impatient-HHs-problems
+- /materials/micro-and-macro-Implications-of-very-impatient-hhs-Problems
+- /materials/micro-and-macro-Implications-of-very-impatient-hhs-problems
+- /materials/micro-and-macro-implications-of-Very-Impatient-HHs-Problems
+- /materials/micro-and-macro-implications-of-Very-Impatient-HHs-problems
+- /materials/micro-and-macro-implications-of-Very-Impatient-hhs-Problems
+- /materials/micro-and-macro-implications-of-Very-Impatient-hhs-problems
+- /materials/micro-and-macro-implications-of-Very-impatient-HHs-Problems
+- /materials/micro-and-macro-implications-of-Very-impatient-HHs-problems
+- /materials/micro-and-macro-implications-of-Very-impatient-hhs-Problems
+- /materials/micro-and-macro-implications-of-Very-impatient-hhs-problems
+- /materials/micro-and-macro-implications-of-very-Impatient-HHs-Problems
+- /materials/micro-and-macro-implications-of-very-Impatient-HHs-problems
+- /materials/micro-and-macro-implications-of-very-Impatient-hhs-Problems
+- /materials/micro-and-macro-implications-of-very-Impatient-hhs-problems
+- /materials/micro-and-macro-implications-of-very-impatient-HHs-Problems
+- /materials/micro-and-macro-implications-of-very-impatient-HHs-problems
+- /materials/micro-and-macro-implications-of-very-impatient-hhs-Problems
+- /materials/micro-and-macro-implications-of-very-impatient-hhs-problems
 ---
 
 Micro- and Macroeconomic Implications of Very Impatient Households

--- a/_materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs.md
+++ b/_materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs.md
@@ -1,21 +1,84 @@
 ---
 name: Micro-and-Macro-Implications-of-Very-Impatient-HHs
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-  - Teaching
-abstract: 'Micro- and Macroeconomic Implications of Very Impatient Households'
+- DemARK
+- Demonstration
+- Notebook
+- Teaching
+abstract: Micro- and Macroeconomic Implications of Very Impatient Households
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
-dashboards:
+- notebooks/Micro-and-Macro-Implications-of-Very-Impatient-HHs.ipynb
+dashboards: null
+redirects_from:
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-HHs
+- /materials/Micro-and-Macro-Implications-of-Very-Impatient-hhs
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-HHs
+- /materials/Micro-and-Macro-Implications-of-Very-impatient-hhs
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-HHs
+- /materials/Micro-and-Macro-Implications-of-very-Impatient-hhs
+- /materials/Micro-and-Macro-Implications-of-very-impatient-HHs
+- /materials/Micro-and-Macro-Implications-of-very-impatient-hhs
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-HHs
+- /materials/Micro-and-Macro-implications-of-Very-Impatient-hhs
+- /materials/Micro-and-Macro-implications-of-Very-impatient-HHs
+- /materials/Micro-and-Macro-implications-of-Very-impatient-hhs
+- /materials/Micro-and-Macro-implications-of-very-Impatient-HHs
+- /materials/Micro-and-Macro-implications-of-very-Impatient-hhs
+- /materials/Micro-and-Macro-implications-of-very-impatient-HHs
+- /materials/Micro-and-Macro-implications-of-very-impatient-hhs
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-HHs
+- /materials/Micro-and-macro-Implications-of-Very-Impatient-hhs
+- /materials/Micro-and-macro-Implications-of-Very-impatient-HHs
+- /materials/Micro-and-macro-Implications-of-Very-impatient-hhs
+- /materials/Micro-and-macro-Implications-of-very-Impatient-HHs
+- /materials/Micro-and-macro-Implications-of-very-Impatient-hhs
+- /materials/Micro-and-macro-Implications-of-very-impatient-HHs
+- /materials/Micro-and-macro-Implications-of-very-impatient-hhs
+- /materials/Micro-and-macro-implications-of-Very-Impatient-HHs
+- /materials/Micro-and-macro-implications-of-Very-Impatient-hhs
+- /materials/Micro-and-macro-implications-of-Very-impatient-HHs
+- /materials/Micro-and-macro-implications-of-Very-impatient-hhs
+- /materials/Micro-and-macro-implications-of-very-Impatient-HHs
+- /materials/Micro-and-macro-implications-of-very-Impatient-hhs
+- /materials/Micro-and-macro-implications-of-very-impatient-HHs
+- /materials/Micro-and-macro-implications-of-very-impatient-hhs
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-HHs
+- /materials/micro-and-Macro-Implications-of-Very-Impatient-hhs
+- /materials/micro-and-Macro-Implications-of-Very-impatient-HHs
+- /materials/micro-and-Macro-Implications-of-Very-impatient-hhs
+- /materials/micro-and-Macro-Implications-of-very-Impatient-HHs
+- /materials/micro-and-Macro-Implications-of-very-Impatient-hhs
+- /materials/micro-and-Macro-Implications-of-very-impatient-HHs
+- /materials/micro-and-Macro-Implications-of-very-impatient-hhs
+- /materials/micro-and-Macro-implications-of-Very-Impatient-HHs
+- /materials/micro-and-Macro-implications-of-Very-Impatient-hhs
+- /materials/micro-and-Macro-implications-of-Very-impatient-HHs
+- /materials/micro-and-Macro-implications-of-Very-impatient-hhs
+- /materials/micro-and-Macro-implications-of-very-Impatient-HHs
+- /materials/micro-and-Macro-implications-of-very-Impatient-hhs
+- /materials/micro-and-Macro-implications-of-very-impatient-HHs
+- /materials/micro-and-Macro-implications-of-very-impatient-hhs
+- /materials/micro-and-macro-Implications-of-Very-Impatient-HHs
+- /materials/micro-and-macro-Implications-of-Very-Impatient-hhs
+- /materials/micro-and-macro-Implications-of-Very-impatient-HHs
+- /materials/micro-and-macro-Implications-of-Very-impatient-hhs
+- /materials/micro-and-macro-Implications-of-very-Impatient-HHs
+- /materials/micro-and-macro-Implications-of-very-Impatient-hhs
+- /materials/micro-and-macro-Implications-of-very-impatient-HHs
+- /materials/micro-and-macro-Implications-of-very-impatient-hhs
+- /materials/micro-and-macro-implications-of-Very-Impatient-HHs
+- /materials/micro-and-macro-implications-of-Very-Impatient-hhs
+- /materials/micro-and-macro-implications-of-Very-impatient-HHs
+- /materials/micro-and-macro-implications-of-Very-impatient-hhs
+- /materials/micro-and-macro-implications-of-very-Impatient-HHs
+- /materials/micro-and-macro-implications-of-very-Impatient-hhs
+- /materials/micro-and-macro-implications-of-very-impatient-HHs
+- /materials/micro-and-macro-implications-of-very-impatient-hhs
 ---
 
 Micro- and Macroeconomic Implications of Very Impatient Households

--- a/_materials/Nondurables-During-Great-Recession.md
+++ b/_materials/Nondurables-During-Great-Recession.md
@@ -1,20 +1,35 @@
 ---
 name: Nondurables-During-Great-Recession
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'Spending on Nondurables During the Great Recession'
+- DemARK
+- Demonstration
+- Notebook
+abstract: Spending on Nondurables During the Great Recession
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Nondurables-During-Great-Recession.ipynb
-dashboards:
+- notebooks/Nondurables-During-Great-Recession.ipynb
+dashboards: null
+redirects_from:
+- /materials/Nondurables-During-Great-Recession
+- /materials/Nondurables-During-Great-recession
+- /materials/Nondurables-During-great-Recession
+- /materials/Nondurables-During-great-recession
+- /materials/Nondurables-during-Great-Recession
+- /materials/Nondurables-during-Great-recession
+- /materials/Nondurables-during-great-Recession
+- /materials/Nondurables-during-great-recession
+- /materials/nondurables-During-Great-Recession
+- /materials/nondurables-During-Great-recession
+- /materials/nondurables-During-great-Recession
+- /materials/nondurables-During-great-recession
+- /materials/nondurables-during-Great-Recession
+- /materials/nondurables-during-Great-recession
+- /materials/nondurables-during-great-Recession
+- /materials/nondurables-during-great-recession
 ---
 
 Spending on Nondurables During the Great Recession

--- a/_materials/Pandemic.md
+++ b/_materials/Pandemic.md
@@ -1,69 +1,61 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required (don't change)
-message: "To predict the eﬀects of the 2020 U.S. CARES Act on consumption, we extend a model that matches responses of households to past consumption stimulus packages; all results are paired with illustrative numerical solutions." # required
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Crawley"
-    given-names: "Edmund"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "Slacalek"
-    given-names: "Jiri"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "White"
-    given-names: "Matthew N."
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-title: "Modeling the Consumption Response to the CARES Act" # required
-abstract: "To predict the eﬀects of the 2020 U.S. CARES Act on consumption, we extend a model that matches responses of households to past consumption stimulus packages. The extension allows us to account for two novel features of the coronavirus crisis. First, during the lockdown, many types of spending are undesirable or impossible. Second, some of the jobs that disappear during the lockdown will not reappear when it is lifted. We estimate that, if the lockdown is short-lived, the combination of expanded unemployment insurance beneﬁts and stimulus payments should be suﬃcient to allow a swift recovery in consumer spending to its pre-crisis levels. If the lockdown lasts longer, an extension of enhanced unemployment beneﬁts will likely be necessary if consumption spending is to recover." # abstract: optional
-
-# REMARK required fields
-remark-version: "1.0" # required
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Crawley"
-        given-names: "Edmund"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Slacalek"
-        given-names: "Jiri"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "White"
-        given-names: "Matthew N."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "Modeling the Consumption Response to the CARES Act" # required
-    doi: "https://doi.org/10.3386/w27876" # optional
-    date: 2020-09-14 # required
-    publisher: "NBER"
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/Pandemic # required 
-remark-name: Pandemic # required 
-dashboards: # path to any dahsboards within the repo - optional
-  - 
-    Code/Python/dashboard.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Notebook
-
-keywords: # optional
-  - Consumption
-  - COVID-19
-  - Stimulus
-  - Fiscal Policy
+cff-version: 1.1.0
+message: "To predict the e\uFB00ects of the 2020 U.S. CARES Act on consumption, we\
+  \ extend a model that matches responses of households to past consumption stimulus\
+  \ packages; all results are paired with illustrative numerical solutions."
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Crawley
+  given-names: Edmund
+- family-names: Slacalek
+  given-names: Jiri
+- family-names: White
+  given-names: Matthew N.
+title: Modeling the Consumption Response to the CARES Act
+abstract: "To predict the e\uFB00ects of the 2020 U.S. CARES Act on consumption, we\
+  \ extend a model that matches responses of households to past consumption stimulus\
+  \ packages. The extension allows us to account for two novel features of the coronavirus\
+  \ crisis. First, during the lockdown, many types of spending are undesirable or\
+  \ impossible. Second, some of the jobs that disappear during the lockdown will not\
+  \ reappear when it is lifted. We estimate that, if the lockdown is short-lived,\
+  \ the combination of expanded unemployment insurance bene\uFB01ts and stimulus payments\
+  \ should be su\uFB03cient to allow a swift recovery in consumer spending to its\
+  \ pre-crisis levels. If the lockdown lasts longer, an extension of enhanced unemployment\
+  \ bene\uFB01ts will likely be necessary if consumption spending is to recover."
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Crawley
+    given-names: Edmund
+  - family-names: Slacalek
+    given-names: Jiri
+  - family-names: White
+    given-names: Matthew N.
+  title: Modeling the Consumption Response to the CARES Act
+  doi: https://doi.org/10.3386/w27876
+  date: 2020-09-14
+  publisher: NBER
+github_repo_url: https://github.com/econ-ark/Pandemic
+remark-name: Pandemic
+dashboards:
+- Code/Python/dashboard.ipynb
+tags:
+- REMARK
+- Notebook
+keywords:
+- Consumption
+- COVID-19
+- Stimulus
+- Fiscal Policy
+redirects_from:
+- /materials/Pandemic
+- /materials/pandemic
 ---
 
 # Pandemic-ConsumptionResponse

--- a/_materials/PerfForesightCRRA-Approximation.md
+++ b/_materials/PerfForesightCRRA-Approximation.md
@@ -1,21 +1,36 @@
 ---
 name: PerfForesightCRRA-Approximation
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
-abstract: 'Perfect Foresight CRRA Model - Approximation'
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
+abstract: Perfect Foresight CRRA Model - Approximation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/PerfForesightCRRA-Approximation.ipynb
-dashboards:
+- notebooks/PerfForesightCRRA-Approximation.ipynb
+dashboards: null
+redirects_from:
+- /materials/PerfForesightCRRA-Approximation
+- /materials/PerfForesightCRRA-approximation
+- /materials/PerfForesightcrra-Approximation
+- /materials/PerfForesightcrra-approximation
+- /materials/PerfforesightCRRA-Approximation
+- /materials/PerfforesightCRRA-approximation
+- /materials/Perfforesightcrra-Approximation
+- /materials/Perfforesightcrra-approximation
+- /materials/perfForesightCRRA-Approximation
+- /materials/perfForesightCRRA-approximation
+- /materials/perfForesightcrra-Approximation
+- /materials/perfForesightcrra-approximation
+- /materials/perfforesightCRRA-Approximation
+- /materials/perfforesightCRRA-approximation
+- /materials/perfforesightcrra-Approximation
+- /materials/perfforesightcrra-approximation
 ---
 
 Perfect Foresight CRRA Model - Approximation

--- a/_materials/PerfForesightCRRA-SavingRate.md
+++ b/_materials/PerfForesightCRRA-SavingRate.md
@@ -1,21 +1,52 @@
 ---
 name: PerfForesightCRRA-SavingRate
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
-abstract: 'Perfect Foresight CRRA Model - Savings Rate'
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
+abstract: Perfect Foresight CRRA Model - Savings Rate
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/PerfForesightCRRA-SavingRate.ipynb
-dashboards:
+- notebooks/PerfForesightCRRA-SavingRate.ipynb
+dashboards: null
+redirects_from:
+- /materials/PerfForesightCRRA-SavingRate
+- /materials/PerfForesightCRRA-Savingrate
+- /materials/PerfForesightCRRA-savingRate
+- /materials/PerfForesightCRRA-savingrate
+- /materials/PerfForesightcrra-SavingRate
+- /materials/PerfForesightcrra-Savingrate
+- /materials/PerfForesightcrra-savingRate
+- /materials/PerfForesightcrra-savingrate
+- /materials/PerfforesightCRRA-SavingRate
+- /materials/PerfforesightCRRA-Savingrate
+- /materials/PerfforesightCRRA-savingRate
+- /materials/PerfforesightCRRA-savingrate
+- /materials/Perfforesightcrra-SavingRate
+- /materials/Perfforesightcrra-Savingrate
+- /materials/Perfforesightcrra-savingRate
+- /materials/Perfforesightcrra-savingrate
+- /materials/perfForesightCRRA-SavingRate
+- /materials/perfForesightCRRA-Savingrate
+- /materials/perfForesightCRRA-savingRate
+- /materials/perfForesightCRRA-savingrate
+- /materials/perfForesightcrra-SavingRate
+- /materials/perfForesightcrra-Savingrate
+- /materials/perfForesightcrra-savingRate
+- /materials/perfForesightcrra-savingrate
+- /materials/perfforesightCRRA-SavingRate
+- /materials/perfforesightCRRA-Savingrate
+- /materials/perfforesightCRRA-savingRate
+- /materials/perfforesightCRRA-savingrate
+- /materials/perfforesightcrra-SavingRate
+- /materials/perfforesightcrra-Savingrate
+- /materials/perfforesightcrra-savingRate
+- /materials/perfforesightcrra-savingrate
 ---
 
 Perfect Foresight CRRA Model - Savings Rate

--- a/_materials/PerfForesightConsumerType.md
+++ b/_materials/PerfForesightConsumerType.md
@@ -1,22 +1,37 @@
 ---
 name: PerfForesightConsumerType
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'PerfForesightConsumerType Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: PerfForesightConsumerType Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsIndShockModel/PerfForesightConsumerType.ipynb
-dashboards:
+- examples/ConsIndShockModel/PerfForesightConsumerType.ipynb
+dashboards: null
+redirects_from:
+- /materials/PerfForesightConsumerType
+- /materials/PerfForesightConsumertype
+- /materials/PerfForesightconsumerType
+- /materials/PerfForesightconsumertype
+- /materials/PerfforesightConsumerType
+- /materials/PerfforesightConsumertype
+- /materials/PerfforesightconsumerType
+- /materials/Perfforesightconsumertype
+- /materials/perfForesightConsumerType
+- /materials/perfForesightConsumertype
+- /materials/perfForesightconsumerType
+- /materials/perfForesightconsumertype
+- /materials/perfforesightConsumerType
+- /materials/perfforesightConsumertype
+- /materials/perfforesightconsumerType
+- /materials/perfforesightconsumertype
 ---
 
 Detailed description of the `PerfForesightConsumerType` class

--- a/_materials/PortfolioChoiceBlogPost.md
+++ b/_materials/PortfolioChoiceBlogPost.md
@@ -1,33 +1,44 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-authors: # required
-  - family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 title: Optimal Financial Investment over the Life Cycle - Blog Post
-
-# REMARK required fields
-remark-version: "1.0" # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: Blogpost
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: "Optimal Financial Investment over the Life Cycle - Blog Post" # required
-
-# Econ-ARK website fields
+remark-version: '1.0'
+references:
+- type: Blogpost
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: Optimal Financial Investment over the Life Cycle - Blog Post
 github_repo_url: https://github.com/econ-ark/PortfolioChoiceBlogPost
-remark-name: "PortfolioChoiceBlogPost"
-notebooks: # path to any notebooks within the repo - optional
-  - PortfolioChoiceBlogPost.ipynb
+remark-name: PortfolioChoiceBlogPost
+notebooks:
+- PortfolioChoiceBlogPost.ipynb
 tags:
-  - REMARK
-  - Replication
-  - Notebook
-  - Blog
+- REMARK
+- Replication
+- Notebook
+- Blog
+redirects_from:
+- /materials/PortfolioChoiceBlogPost
+- /materials/PortfolioChoiceBlogpost
+- /materials/PortfolioChoiceblogPost
+- /materials/PortfolioChoiceblogpost
+- /materials/PortfoliochoiceBlogPost
+- /materials/PortfoliochoiceBlogpost
+- /materials/PortfoliochoiceblogPost
+- /materials/Portfoliochoiceblogpost
+- /materials/portfolioChoiceBlogPost
+- /materials/portfolioChoiceBlogpost
+- /materials/portfolioChoiceblogPost
+- /materials/portfolioChoiceblogpost
+- /materials/portfoliochoiceBlogPost
+- /materials/portfoliochoiceBlogpost
+- /materials/portfoliochoiceblogPost
+- /materials/portfoliochoiceblogpost
 ---
 
 # PortfolioChoiceBlogPost

--- a/_materials/RiskyContrib.md
+++ b/_materials/RiskyContrib.md
@@ -1,54 +1,47 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required (don't change)
-authors: # required
-  -
-    family-names: "Velásquez-Giraldo"
-    given-names: "Mateo"
+cff-version: 1.1.0
+authors:
+- family-names: "Vel\xE1squez-Giraldo"
+  given-names: Mateo
+  orcid: https://orcid.org/0000-0001-7243-6776
+title: A Two-Asset Savings Model with an Income-Contribution Scheme
+abstract: This paper develops a two-asset consumption-savings model and serves as
+  the documentation of an open-source implementation of methods to solve and simulate
+  it in the HARK toolkit. The model represents an agent who can save using two different
+  assets---one risky and the other risk-free---to insure against fluctuations in his
+  income, but faces frictions to transferring funds between assets. The flexibility
+  of its implementation and its inclusion in the HARK toolkit will allow users to
+  adapt the model to realistic life-cycle calibrations, and also to embedded it in
+  heterogeneous-agents macroeconomic models.
+date-released: 2021-06-17
+remark-version: v1.0.1
+references:
+- type: article
+  authors:
+  - family-names: "Vel\xE1squez-Giraldo"
+    given-names: Mateo
     orcid: https://orcid.org/0000-0001-7243-6776
-title: "A Two-Asset Savings Model with an Income-Contribution Scheme" # required
-abstract: "This paper develops a two-asset consumption-savings model and serves as
-the documentation of an open-source implementation of methods to solve and
-simulate it in the HARK toolkit. The model represents an agent who can
-save using two different assets---one risky and the other risk-free---to insure
-against fluctuations in his income, but faces frictions to transferring funds between
-assets. The flexibility of its implementation and its inclusion in the HARK
-toolkit will allow users to adapt the model to realistic life-cycle calibrations, and
-also to embedded it in heterogeneous-agents macroeconomic models." # optional
-date-released: 2021-06-17 # required
-
-# REMARK required fields
-remark-version: "v1.0.1" # required
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Velásquez-Giraldo"
-        given-names: "Mateo"
-        orcid: https://orcid.org/0000-0001-7243-6776
-      -
-        family-names: "Author 2 Last Name"
-        given-names: "Author 2 First Name"
-        orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "A Two-Asset Savings Model with an Income-Contribution Scheme" # required
-    doi: "https://zenodo.org/badge/DOI/10.5281/zenodo.4974234.svg" # optional
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/Mv77/RiskyContrib # required
-remark-name: RiskyContrib # required
-notebooks: # path to any notebooks within the repo - optional
-  -
-    Code/Python/RiskyContrib.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-
-keywords: # optional
-  - Lifecycle
-  - Portfolio Choice
-  - Social Security
-  - Open Source
-
+  - family-names: Author 2 Last Name
+    given-names: Author 2 First Name
+    orcid: https://orcid.org/XXXX-XXXX-XXXX-XXXX
+  title: A Two-Asset Savings Model with an Income-Contribution Scheme
+  doi: https://zenodo.org/badge/DOI/10.5281/zenodo.4974234.svg
+github_repo_url: https://github.com/Mv77/RiskyContrib
+remark-name: RiskyContrib
+notebooks:
+- Code/Python/RiskyContrib.ipynb
+tags:
+- REMARK
+keywords:
+- Lifecycle
+- Portfolio Choice
+- Social Security
+- Open Source
+redirects_from:
+- /materials/RiskyContrib
+- /materials/Riskycontrib
+- /materials/riskyContrib
+- /materials/riskycontrib
 ---
 
 # A Two-Asset Savings Model with an Income-Contribution Scheme

--- a/_materials/SolvingMicroDSOPs.md
+++ b/_materials/SolvingMicroDSOPs.md
@@ -1,51 +1,55 @@
 ---
-# CFF required fields
-cff-version: "1.1.0" # required 
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Wang"
-    given-names: "Tao"
-    orcid: "https://orcid.org/0000-0003-4806-8592"
-title: "Solution Methods for Microeconomic Dynamic Stochastic Optimization Problems" # required
-abstract: "These notes describe tools for solving microeconomic dynamic stochastic optimization problems, and show how to use those tools for efficiently estimating a standard life cycle consumption/saving model using microeconomic data.  No attempt is made at a systematic overview of the many possible technical choices; instead, I present a specific set of methods that have proven useful in my own work (and explain why other popular methods, such as value function iteration, are a bad idea).  Paired with these notes is Mathematica, Matlab, and Python software that solves the problems described in the text." # abstract: optional
-date-released: 2021-02-20 # required
-
-# REMARK required fields
-remark-version: "1.0" # required
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Wang
+  given-names: Tao
+  orcid: https://orcid.org/0000-0003-4806-8592
+title: Solution Methods for Microeconomic Dynamic Stochastic Optimization Problems
+abstract: These notes describe tools for solving microeconomic dynamic stochastic
+  optimization problems, and show how to use those tools for efficiently estimating
+  a standard life cycle consumption/saving model using microeconomic data.  No attempt
+  is made at a systematic overview of the many possible technical choices; instead,
+  I present a specific set of methods that have proven useful in my own work (and
+  explain why other popular methods, such as value function iteration, are a bad idea).  Paired
+  with these notes is Mathematica, Matlab, and Python software that solves the problems
+  described in the text.
+date-released: 2021-02-20
+remark-version: '1.0'
 references:
-  - type: lecture-notes
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-    title: "Solution Methods for Microeconomic Dynamic Stochastic Optimization Problems"
-    repository: "https://github.com/llorracc/SolvingMicroDSOPs" # optional
-
-# Econ-ARK website fields
-github_repo_url: https://github.com/econ-ark/SolvingMicroDSOPs # required 
-remark-name: SolvingMicroDSOPs # required 
-notebooks: # path to any notebooks within the repo - optional
-  - SolvingMicroDSOPs-Python.ipynb
-       
-identifiers: # optional
-  - 
-    type: url
-    value: "https://llorracc.github.io/SolvingMicroDSOPs"
-
+- type: lecture-notes
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  title: Solution Methods for Microeconomic Dynamic Stochastic Optimization Problems
+  repository: https://github.com/llorracc/SolvingMicroDSOPs
+github_repo_url: https://github.com/econ-ark/SolvingMicroDSOPs
+remark-name: SolvingMicroDSOPs
+notebooks:
+- SolvingMicroDSOPs-Python.ipynb
+identifiers:
+- type: url
+  value: https://llorracc.github.io/SolvingMicroDSOPs
 tags:
-  - REMARK
-  - Replication
-  - Teaching
-  - Tutorial
-
-keywords: # optional
-  - Consumption
-  - Saving 
+- REMARK
+- Replication
+- Teaching
+- Tutorial
+keywords:
+- Consumption
+- Saving
+redirects_from:
+- /materials/SolvingMicroDSOPs
+- /materials/SolvingMicrodsops
+- /materials/SolvingmicroDSOPs
+- /materials/Solvingmicrodsops
+- /materials/solvingMicroDSOPs
+- /materials/solvingMicrodsops
+- /materials/solvingmicroDSOPs
+- /materials/solvingmicrodsops
 ---
 
 # Solution Methods for Microeconomic Dynamic Stochastic Optimization Problems

--- a/_materials/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.md
+++ b/_materials/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.md
@@ -1,32 +1,92 @@
 ---
 name: Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: 'Making Structural Estimates From Empirical Results'
+- DemARK
+- Demonstration
+- Notebook
+abstract: Making Structural Estimates From Empirical Results
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: White
-    given-names: "Matthew N."
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: White
+  given-names: Matthew N.
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.ipynb
-dashboards:
-title-original-paper: MPC heterogeneity and household balance sheets # required for Replications
-identifiers-paper: # required for Replications; optional for Reproductions
-   -
-      type: url
-      value: https://economicdynamics.org/meetpapers/2017/paper_65.pdf
-   -
-      type: url published paper
-      value: https://www.aeaweb.org/articles?id=10.1257/mac.20190211
-date-published-original-paper: 2016-11 # required for Replications; optional for Reproductions
+- notebooks/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al.ipynb
+dashboards: null
+title-original-paper: MPC heterogeneity and household balance sheets
+identifiers-paper:
+- type: url
+  value: https://economicdynamics.org/meetpapers/2017/paper_65.pdf
+- type: url published paper
+  value: https://www.aeaweb.org/articles?id=10.1257/mac.20190211
+date-published-original-paper: 2016-11
+redirects_from:
+- /materials/Structural-Estimates-From-Empirical-MPCs-Fagereng-et-al
+- /materials/Structural-Estimates-From-Empirical-MPCs-fagereng-et-al
+- /materials/Structural-Estimates-From-Empirical-mpcs-Fagereng-et-al
+- /materials/Structural-Estimates-From-Empirical-mpcs-fagereng-et-al
+- /materials/Structural-Estimates-From-empirical-MPCs-Fagereng-et-al
+- /materials/Structural-Estimates-From-empirical-MPCs-fagereng-et-al
+- /materials/Structural-Estimates-From-empirical-mpcs-Fagereng-et-al
+- /materials/Structural-Estimates-From-empirical-mpcs-fagereng-et-al
+- /materials/Structural-Estimates-from-Empirical-MPCs-Fagereng-et-al
+- /materials/Structural-Estimates-from-Empirical-MPCs-fagereng-et-al
+- /materials/Structural-Estimates-from-Empirical-mpcs-Fagereng-et-al
+- /materials/Structural-Estimates-from-Empirical-mpcs-fagereng-et-al
+- /materials/Structural-Estimates-from-empirical-MPCs-Fagereng-et-al
+- /materials/Structural-Estimates-from-empirical-MPCs-fagereng-et-al
+- /materials/Structural-Estimates-from-empirical-mpcs-Fagereng-et-al
+- /materials/Structural-Estimates-from-empirical-mpcs-fagereng-et-al
+- /materials/Structural-estimates-From-Empirical-MPCs-Fagereng-et-al
+- /materials/Structural-estimates-From-Empirical-MPCs-fagereng-et-al
+- /materials/Structural-estimates-From-Empirical-mpcs-Fagereng-et-al
+- /materials/Structural-estimates-From-Empirical-mpcs-fagereng-et-al
+- /materials/Structural-estimates-From-empirical-MPCs-Fagereng-et-al
+- /materials/Structural-estimates-From-empirical-MPCs-fagereng-et-al
+- /materials/Structural-estimates-From-empirical-mpcs-Fagereng-et-al
+- /materials/Structural-estimates-From-empirical-mpcs-fagereng-et-al
+- /materials/Structural-estimates-from-Empirical-MPCs-Fagereng-et-al
+- /materials/Structural-estimates-from-Empirical-MPCs-fagereng-et-al
+- /materials/Structural-estimates-from-Empirical-mpcs-Fagereng-et-al
+- /materials/Structural-estimates-from-Empirical-mpcs-fagereng-et-al
+- /materials/Structural-estimates-from-empirical-MPCs-Fagereng-et-al
+- /materials/Structural-estimates-from-empirical-MPCs-fagereng-et-al
+- /materials/Structural-estimates-from-empirical-mpcs-Fagereng-et-al
+- /materials/Structural-estimates-from-empirical-mpcs-fagereng-et-al
+- /materials/structural-Estimates-From-Empirical-MPCs-Fagereng-et-al
+- /materials/structural-Estimates-From-Empirical-MPCs-fagereng-et-al
+- /materials/structural-Estimates-From-Empirical-mpcs-Fagereng-et-al
+- /materials/structural-Estimates-From-Empirical-mpcs-fagereng-et-al
+- /materials/structural-Estimates-From-empirical-MPCs-Fagereng-et-al
+- /materials/structural-Estimates-From-empirical-MPCs-fagereng-et-al
+- /materials/structural-Estimates-From-empirical-mpcs-Fagereng-et-al
+- /materials/structural-Estimates-From-empirical-mpcs-fagereng-et-al
+- /materials/structural-Estimates-from-Empirical-MPCs-Fagereng-et-al
+- /materials/structural-Estimates-from-Empirical-MPCs-fagereng-et-al
+- /materials/structural-Estimates-from-Empirical-mpcs-Fagereng-et-al
+- /materials/structural-Estimates-from-Empirical-mpcs-fagereng-et-al
+- /materials/structural-Estimates-from-empirical-MPCs-Fagereng-et-al
+- /materials/structural-Estimates-from-empirical-MPCs-fagereng-et-al
+- /materials/structural-Estimates-from-empirical-mpcs-Fagereng-et-al
+- /materials/structural-Estimates-from-empirical-mpcs-fagereng-et-al
+- /materials/structural-estimates-From-Empirical-MPCs-Fagereng-et-al
+- /materials/structural-estimates-From-Empirical-MPCs-fagereng-et-al
+- /materials/structural-estimates-From-Empirical-mpcs-Fagereng-et-al
+- /materials/structural-estimates-From-Empirical-mpcs-fagereng-et-al
+- /materials/structural-estimates-From-empirical-MPCs-Fagereng-et-al
+- /materials/structural-estimates-From-empirical-MPCs-fagereng-et-al
+- /materials/structural-estimates-From-empirical-mpcs-Fagereng-et-al
+- /materials/structural-estimates-From-empirical-mpcs-fagereng-et-al
+- /materials/structural-estimates-from-Empirical-MPCs-Fagereng-et-al
+- /materials/structural-estimates-from-Empirical-MPCs-fagereng-et-al
+- /materials/structural-estimates-from-Empirical-mpcs-Fagereng-et-al
+- /materials/structural-estimates-from-Empirical-mpcs-fagereng-et-al
+- /materials/structural-estimates-from-empirical-MPCs-Fagereng-et-al
+- /materials/structural-estimates-from-empirical-MPCs-fagereng-et-al
+- /materials/structural-estimates-from-empirical-mpcs-Fagereng-et-al
+- /materials/structural-estimates-from-empirical-mpcs-fagereng-et-al
 ---
 
 Making Structural Estimates From Empirical Results

--- a/_materials/TractableBufferStock-Interactive.md
+++ b/_materials/TractableBufferStock-Interactive.md
@@ -1,21 +1,36 @@
 ---
 name: TractableBufferStock-Interactive
 tags:
-  - DemARK
-  - Demonstration
-  - Teaching
-  - Notebook
-abstract: 'The Tractable Buffer Stock Model'
+- DemARK
+- Demonstration
+- Teaching
+- Notebook
+abstract: The Tractable Buffer Stock Model
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/TractableBufferStock-Interactive.ipynb
-dashboards:
+- notebooks/TractableBufferStock-Interactive.ipynb
+dashboards: null
+redirects_from:
+- /materials/TractableBufferStock-Interactive
+- /materials/TractableBufferStock-interactive
+- /materials/TractableBufferstock-Interactive
+- /materials/TractableBufferstock-interactive
+- /materials/TractablebufferStock-Interactive
+- /materials/TractablebufferStock-interactive
+- /materials/Tractablebufferstock-Interactive
+- /materials/Tractablebufferstock-interactive
+- /materials/tractableBufferStock-Interactive
+- /materials/tractableBufferStock-interactive
+- /materials/tractableBufferstock-Interactive
+- /materials/tractableBufferstock-interactive
+- /materials/tractablebufferStock-Interactive
+- /materials/tractablebufferStock-interactive
+- /materials/tractablebufferstock-Interactive
+- /materials/tractablebufferstock-interactive
 ---
 
 The Tractable Buffer Stock Model

--- a/_materials/TractableBufferStockModel.md
+++ b/_materials/TractableBufferStockModel.md
@@ -1,22 +1,37 @@
 ---
 name: TractableBufferStockModel
 tags:
-  - Example
-  - Demonstration
-  - Documentation
-  - Notebook
-  - Teaching
-abstract: 'TractableBufferStockModel Documentation'
+- Example
+- Demonstration
+- Documentation
+- Notebook
+- Teaching
+abstract: TractableBufferStockModel Documentation
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
 github_repo_url: https://github.com/econ-ark/HARK
 notebooks:
-  - 
-    examples/ConsumptionSaving/example_TractableBufferStockModel.ipynb
-dashboards:
+- examples/ConsumptionSaving/example_TractableBufferStockModel.ipynb
+dashboards: null
+redirects_from:
+- /materials/TractableBufferStockModel
+- /materials/TractableBufferStockmodel
+- /materials/TractableBufferstockModel
+- /materials/TractableBufferstockmodel
+- /materials/TractablebufferStockModel
+- /materials/TractablebufferStockmodel
+- /materials/TractablebufferstockModel
+- /materials/Tractablebufferstockmodel
+- /materials/tractableBufferStockModel
+- /materials/tractableBufferStockmodel
+- /materials/tractableBufferstockModel
+- /materials/tractableBufferstockmodel
+- /materials/tractablebufferStockModel
+- /materials/tractablebufferStockmodel
+- /materials/tractablebufferstockModel
+- /materials/tractablebufferstockmodel
 ---
 
 Detailed description of `TractableBufferStockModel` 

--- a/_materials/chinese-growth.md
+++ b/_materials/chinese-growth.md
@@ -1,21 +1,21 @@
 ---
 name: Chinese Growth
 tags:
-  - DemARK
-  - Demonstration
-  - Notebook
-abstract: "Do Precautionary Motives Explain China's High Saving Rate?"
+- DemARK
+- Demonstration
+- Notebook
+abstract: Do Precautionary Motives Explain China's High Saving Rate?
 authors:
-  -
-    family-names: Carroll
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-date-released: 
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+date-released: null
 github_repo_url: https://github.com/econ-ark/DemARK
 notebooks:
-  - 
-    notebooks/Chinese-Growth.ipynb
-dashboards:
+- notebooks/Chinese-Growth.ipynb
+dashboards: null
+redirects_from:
+- /materials/chinese-growth
 ---
 
 Do Precautionary Motives Explain China's High Saving Rate ?

--- a/_materials/cstwMPC-RHetero.md
+++ b/_materials/cstwMPC-RHetero.md
@@ -1,20 +1,26 @@
 ---
 tags:
-  - REMARK
-  - Replication
+- REMARK
+- Replication
 name: cstwMPC-RHetero
-title: Can Persistent Unobserved Heterogeneity in Returns-to-Wealth Explain Wealth Inequality?
+title: Can Persistent Unobserved Heterogeneity in Returns-to-Wealth Explain Wealth
+  Inequality?
 remark_title: cstwMPC-RHetero
 summary: ''
 abstract: ''
 notebook: ''
 authors:
-  - 
+- null
 remark_authors:
-  - Derin Aksit
-paper_url: 
+- Derin Aksit
+paper_url: null
 github_url: https://github.com/econ-ark/cstwMPC-RHetero
 DOI: ''
+redirects_from:
+- /materials/cstwMPC-RHetero
+- /materials/cstwMPC-rhetero
+- /materials/cstwmpc-RHetero
+- /materials/cstwmpc-rhetero
 ---
 
 #AksitRHetero is a Reproduction 

--- a/_materials/cstwMPC.md
+++ b/_materials/cstwMPC.md
@@ -1,59 +1,44 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-message: The results of this paper are now generated in an updated repository using a more modern version of HARK, https://github.com/econ-ark/DistributionOfWealthMPC. Any followup work should build on the updated code in that repository. # optional
-authors: # required
-  -
-    family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-  -
-    family-names: "Slacalek"
-    given-names: "Jiri"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "Kiichi"
-    given-names: "Tokuoka"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-  -
-    family-names: "White"
-    given-names: "Matthew"
-    # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
+cff-version: 1.1.0
+message: The results of this paper are now generated in an updated repository using
+  a more modern version of HARK, https://github.com/econ-ark/DistributionOfWealthMPC.
+  Any followup work should build on the updated code in that repository.
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+- family-names: Slacalek
+  given-names: Jiri
+- family-names: Kiichi
+  given-names: Tokuoka
+- family-names: White
+  given-names: Matthew
 title: cstwMPC
-
-# REMARK required fields
 remark-version: 2.0
-references: 
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Slacalek"
-        given-names: "Jiri"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "Kiichi"
-        given-names: "Tokuoka"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-      -
-        family-names: "White"
-        given-names: "Matthew N."
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "The distribution of wealth and the marginal propensity to consume" # required
-    doi: "https://doi.org/10.3982/QE694"
-    date: 2017-11-20
-    publisher: Quantitative Economics
-
-# Econ-ARK website fields
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Slacalek
+    given-names: Jiri
+  - family-names: Kiichi
+    given-names: Tokuoka
+  - family-names: White
+    given-names: Matthew N.
+  title: The distribution of wealth and the marginal propensity to consume
+  doi: https://doi.org/10.3982/QE694
+  date: 2017-11-20
+  publisher: Quantitative Economics
 github_repo_url: https://github.com/llorracc/cstwMPC
 remark-name: cstwMPC
-
-tags: # Use the relevant tags
-  - REMARK
-  - Replication
+tags:
+- REMARK
+- Replication
+redirects_from:
+- /materials/cstwMPC
+- /materials/cstwmpc
 ---
 
 

--- a/_materials/ctDiscrete.md
+++ b/_materials/ctDiscrete.md
@@ -1,41 +1,35 @@
 ---
-# CFF required fields
-cff-version: 1.1.0 # required (don't change)
-#message: If you use this software, please cite it as below. # optional
-authors: # required
-  - family-names: "Carroll"
-    given-names: "Christopher D."
-    orcid: "https://orcid.org/0000-0003-3732-9312"
-title: ctDiscrete # required
-abstract: 'Analytically tractable model of the effects of nonfinancial risk on intertemporal choice'  # optional
-
-# REMARK required fields
-remark-version: "1.0"  # required - specify version of REMARK standard used
-references: # required for replications; optional for reproductions; BibTex data from original paper
-  - type: article
-    authors: # required
-      -
-        family-names: "Carroll"
-        given-names: "Christopher D."
-        orcid: "https://orcid.org/0000-0003-3732-9312"
-      -
-        family-names: "Toche"
-        given-names: "Patrick"
-        # orcid: "https://orcid.org/XXXX-XXXX-XXXX-XXXX"
-    title: "A Tractable Model of Buffer Stock Saving" # required
-    doi: "https://doi.org/10.3386/w15265" # optional
-    date: 2009-08 # required
-    publisher: "NBER"
-
-# Econ-ARK website fields
-github_repo_url:  https://github.com/llorracc/ctDiscrete # required
-remark-name: ctDiscrete # required
-notebooks:  # path to any notebooks within the repo - optional
-  - Code/HARK/Examples/ctDiscrete/TractableBufferStockModel.ipynb
-
-tags: # Use the relavent tags
-  - REMARK
-  - Replication
+cff-version: 1.1.0
+authors:
+- family-names: Carroll
+  given-names: Christopher D.
+  orcid: https://orcid.org/0000-0003-3732-9312
+title: ctDiscrete
+abstract: Analytically tractable model of the effects of nonfinancial risk on intertemporal
+  choice
+remark-version: '1.0'
+references:
+- type: article
+  authors:
+  - family-names: Carroll
+    given-names: Christopher D.
+    orcid: https://orcid.org/0000-0003-3732-9312
+  - family-names: Toche
+    given-names: Patrick
+  title: A Tractable Model of Buffer Stock Saving
+  doi: https://doi.org/10.3386/w15265
+  date: 2009-08
+  publisher: NBER
+github_repo_url: https://github.com/llorracc/ctDiscrete
+remark-name: ctDiscrete
+notebooks:
+- Code/HARK/Examples/ctDiscrete/TractableBufferStockModel.ipynb
+tags:
+- REMARK
+- Replication
+redirects_from:
+- /materials/ctDiscrete
+- /materials/ctdiscrete
 ---
 
 # TractableBufferStockModel


### PR DESCRIPTION
Addresses the case-sensitivity in the materials urls via the github-pages supported `jekyll-redirect-from` plugin.

Longer term solutions will require a larger rewrite of the site infrastructure (incorporating a custom jekyll build and a new github action, or using our own web server). In the meantime, this will solve *most* case sensitivity issues for the materials pages.