### PR TITLE
fix econ-ark.org/materials table spacing

### DIFF
--- a/assets/sass/_main.scss
+++ b/assets/sass/_main.scss
@@ -444,7 +444,7 @@ a.action-button {
     margin:0;
     font-size:0.9rem;
     display: inline-block;
-    white-space: nowrap;
+    white-space: wrap;
     @media (max-width: 1023px) {
       white-space: normal;
     }
@@ -483,11 +483,12 @@ a.action-button {
     margin:0.5rem 0 0 0;
     padding:0;
     display:flex;
+    flex-wrap: wrap;
     opacity: 0.7;
     //justify-content: flex-end;
     //flex-direction: column;
     li {
-      margin:0 0.25rem 0 0;
+      margin:0 0.25rem 0.25rem 0;
       font-size: 0.8rem;
       padding: 0.25rem 1rem 0.25rem 1rem;
       //min-width: 100px;


### PR DESCRIPTION
This commit fixes the spacing on the `/materials` page where the 'Abstract' column is overflowing and being hidden. This fix changes allows the left-hand column 'Material' to allow both the title and the tags to wrap.

Current Display (note the right hand column being cut off)
![image](https://github.com/econ-ark/econ-ark.org/assets/96146940/ef72f92e-01b7-425d-80db-ab2c43624ff9)

New Display after commit:
![image](https://github.com/econ-ark/econ-ark.org/assets/96146940/1c1d4a18-374e-494f-8331-19e5298e2508)
