### PR TITLE
Upgrade to GA4

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -2,13 +2,13 @@
 <html class="no-js" lang="en">
     <head>
 
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-54984338-5"></script>
+        <!-- Google tag (gtag.js) -->
+        <script async src="https://www.googletagmanager.com/gtag/js?id=G-X64TQYYWX3"></script>
         <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-
-        gtag('config', '{{ site.google_analytics }}');
+          window.dataLayer = window.dataLayer || [];
+          function gtag(){dataLayer.push(arguments);}
+          gtag('js', new Date());
+          gtag('config', 'G-X64TQYYWX3');
         </script>
 
         <meta charset="utf-8">


### PR DESCRIPTION
Replace Google UA tracker tag with latest Google Analytics 4.