### PR TITLE
Show 'Edit metadata' link on material pages

### DIFF
--- a/_layouts/material.html
+++ b/_layouts/material.html
@@ -6,6 +6,24 @@ layout: default
 {% assign github_repo = github_parts[0] %}
 {% assign github_user = github_parts[1] %}
 
+{% if page.remark-name %}
+    {% assign edit_href = 'https://github.com/econ-ark/REMARK/edit/master/REMARKs/' | append: page.remark-name | append: '.md' %}
+    {% assign edit_href = edit_href | replace: ' ', '-' %}
+{% endif %}
+
+{% if page.github_repo_url contains 'HARK' %}
+    {% assign edit_href = 'https://github.com/econ-ark/econ-ark.org/edit/master/_materials/' | append: page.name | append: '.md' %}
+    {% assign edit_href = edit_href | replace: ' ', '-' %}
+{% endif %}
+
+{% if page.github_repo_url contains 'DemARK' %}
+    {% assign edit_href = 'https://github.com/econ-ark/DemARK/edit/master/markdown/' | append: page.name | append: '.md' %}
+    {% assign edit_href = edit_href | replace: ' ', '-' %}
+{% endif %} 
+
+
+<!-- https://github.com/econ-ark/DemARK/edit/master/markdown/Chinese-Growth.md -->
+<!-- https://github.com/econ-ark/REMARK/edit/master/REMARKs/Aiyagari.md -->
 
 <script type="text/javascript">
     if (top.location!= self.location){
@@ -290,6 +308,10 @@ layout: default
     <div class="panel-head">
 
         <h2 class="heading">Metadata</h2>
+        
+{% if edit_href %}
+        <p class="altheading"><a href="{{ edit_href }}">Edit metadata</a></p>
+{% endif %}
 
     </div>
 

--- a/assets/sass/_material.scss
+++ b/assets/sass/_material.scss
@@ -13,6 +13,9 @@
         padding:1.5rem 2rem 1.2rem 2rem;
         border-bottom:1px solid #e2e8ec;
         background:  #f7fafb;
+        display: flex;
+        justify-content: space-between;
+        align-items: center;
         .heading {
             font-size:1.3rem;
             margin:0;
@@ -24,6 +27,12 @@
             margin:0.5rem 0 0 0;
             font-weight: 500;
             color: rgb(138, 138, 138);
+        }
+        .altheading {
+            margin:0;
+            a {
+                
+            }
         }
     }
     .panel-content {


### PR DESCRIPTION
Addresses issue #17 
This PR adds a direct link to editing the metadata for a material on GitHub.
Note: If GitHub user doesn't not have edit permissions they will have the option of forking.

![image](https://github.com/econ-ark/econ-ark.org/assets/5886045/b9b4b01f-7913-41ac-a986-0f0164eedadf)
