### PR TITLE
Potential fix for links without trailing forward slash

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -27,7 +27,7 @@ exclude:
 collections:
   materials:
     output: true
-    permalink: /materials/:name
+    permalink: /materials/:name/
   team:
 
 defaults:


### PR DESCRIPTION
On the homepage, links to the materials section (eg. Materials Library heading) do not work if they have a trailing forward slash. Result in 404.

Addressing issue #60 

Working: "https://econ-ark.org/materials"
Causing 404: "https://econ-ark.org/materials/"

Implementing config update as potential fix, from:
https://stackoverflow.com/questions/54727643/trailing-slashes-in-jekyll-github-pages-site-cause-404

<img width="792" alt="image" src="https://github.com/econ-ark/econ-ark.org/assets/5886045/42ba238a-bbc2-4c8b-ae5d-ac22aed6a1ee">
