### PR TITLE
Promoting REMARK 'App Library' onto homepage…

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,134 +1,150 @@
 <!doctype html>
 <html class="no-js" lang="en">
-    <head>
 
-        <script async src="https://www.googletagmanager.com/gtag/js?id=UA-54984338-5"></script>
-        <script>
+<head>
+
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-54984338-5"></script>
+    <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
+        function gtag() { dataLayer.push(arguments); }
         gtag('js', new Date());
 
         gtag('config', '{{ site.google_analytics }}');
-        </script>
+    </script>
 
-        <meta charset="utf-8">
-        <meta http-equiv="x-ua-compatible" content="ie=edge">
-        <title>{{ page.title }} &ndash; {{ site.title }}</title>
+    <meta charset="utf-8">
+    <meta http-equiv="x-ua-compatible" content="ie=edge">
+    <title>{{ page.title }} &ndash; {{ site.title }}</title>
 
-        <meta name="viewport" content="width=device-width, initial-scale=1">
-        <!-- <link rel="icon" href="{{ '/assets/img/favicon.ico' | relative_url }}" type="image/x-icon" /> -->
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- <link rel="icon" href="{{ '/assets/img/favicon.ico' | relative_url }}" type="image/x-icon" /> -->
 
-        <meta name="author" content="{{ site.author }}">
-        <meta name="keywords" content="{{ site.keywords }}">
-        <meta name="description" content="{{ site.description }}">
+    <meta name="author" content="{{ site.author }}">
+    <meta name="keywords" content="{{ site.keywords }}">
+    <meta name="description" content="{{ site.description }}">
 
-        <meta property="og:title" content="{{ page.title }}" />
-        <meta property="og:type" content="website" />
-        <meta property="og:url" content="https://econ-ark.org{{ page.url }}" />
-        <meta property="og:image" content="https://econ-ark.org/assets/img/econ-ark-logo.png" />
-        <meta property="og:description" content="{{ site.description }}" />
-        <meta property="og:site_name" content="{{ site.title }}" />
+    <meta property="og:title" content="{{ page.title }}" />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://econ-ark.org{{ page.url }}" />
+    <meta property="og:image" content="https://econ-ark.org/assets/img/econ-ark-logo.png" />
+    <meta property="og:description" content="{{ site.description }}" />
+    <meta property="og:site_name" content="{{ site.title }}" />
 
-        <script src="https://kit.fontawesome.com/8281de4b75.js" crossorigin="anonymous"></script>
+    <script src="https://kit.fontawesome.com/8281de4b75.js" crossorigin="anonymous"></script>
 
-        <link href="//fonts.googleapis.com/css?family=Varela+Round|Roboto:400,500,700&display=swap" rel="stylesheet">
+    <link href="//fonts.googleapis.com/css?family=Varela+Round|Roboto:400,500,700&display=swap" rel="stylesheet">
 
-        <!-- Include CSS -->
-        <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
-        <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css" />
-        <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
-        <link rel="stylesheet" href="/assets/main.css?v=1.1">
-        
-    </head>
-    <body class="language-python{% if page.layout == 'home' %} home{% endif %}">
+    <!-- Include CSS -->
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/choices.js/public/assets/styles/choices.min.css">
+    <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.css" />
+    <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/css/bootstrap.min.css" rel="stylesheet"
+        integrity="sha384-T3c6CoIi6uLrA9TneNEoa7RxnatzjcDSCmG1MXxSR1GAsXEV/Dwwykc2MPK8M2HN" crossorigin="anonymous">
+    <link rel="stylesheet" href="/assets/main.css?v=1.1">
 
-        <header class="header">
+</head>
 
-            <a title="Toggle navigation" id="toggleNav" class="toggle-nav"><i class="fas fa-bars"></i></a>
+<body class="language-python{% if page.layout == 'home' %} home{% endif %}">
 
-            <div class="container">
+    <header class="header">
 
-                <p class="site-logo"><a href="/"><img src="{{ '/assets/img/econ-ark-logo-white.png' | relative_url }}"></a></p>
+        <a title="Toggle navigation" id="toggleNav" class="toggle-nav"><i class="fas fa-bars"></i></a>
 
-                <nav class="navigation">
+        <div class="container">
 
-                    <ul>
-{% assign pages = site.pages | where: "menu_item", "true" | sort:"order" %}
-{% for node in pages %}
-                      <li class="{% if page.url == node.url %}active{% endif %}"><a href="{{ node.url | relative_url }}">{{ node.title }}</a></li>
-{% endfor %}
+            <p class="site-logo"><a href="/"><img src="{{ '/assets/img/econ-ark-logo-white.png' | relative_url }}"></a>
+            </p>
 
-                        <li><a href="https://docs.econ-ark.org">Docs</a></li>
-                        <li><a href="https://github.com/econ-ark">GitHub</a></li>
-                    </ul>
+            <nav class="navigation">
 
-                </nav>
+                <ul>
+                    <li class="active"><a href="">Home</a></li>
+                    <li class=""><a href="https://docs.econ-ark.org/overview/introduction.html">HARK</a></li>
+                    <li class=""><a href="/materials/">App Library</a></li>
+                    <li class=""><a href="/materials/">Teaching</a></li>
+                    <li><a href="https://docs.econ-ark.org">Docs</a></li>
+                    <li><a href="https://github.com/econ-ark">GitHub</a></li>
+                </ul>
 
-            </div>
+            </nav>
 
-        </header>
+        </div>
 
-        <main>
+    </header>
 
-{% if page.layout != "home" %}
-            <div class="container">
-{% endif %}
+    <main>
 
-{{ content }}
+        {% if page.layout != "home" %}
+        <div class="container">
+            {% endif %}
 
-{% if page.layout != "home" %}
-            </div>
-{% endif %}
+            {{ content }}
 
-        </main>
+            {% if page.layout != "home" %}
+        </div>
+        {% endif %}
 
-        <footer class="footer px-5">
+    </main>
 
-            <div class="container">
+    <footer class="footer px-5">
 
-                <div class="row gx-5">
+        <div class="container">
 
-                    <div class="col-md-7">
+            <div class="row gx-5">
 
-                        <p>Econ-ARK is headed by <a href="http://www.econ2.jhu.edu/people/ccarroll/">Christopher D. Carroll</a>, Professor of Economics at the Johns Hopkins University.</p>
+                <div class="col-md-7">
 
-                        <p>The project is a recipient of grants from the <a href="https://sloan.org/">Sloan foundation</a> and the <a href="https://www.thinkforwardinitiative.com/">Think Forward Initiative</a>, and is under the umbrella of projects with fiscal sponsorship by <a href="https://www.numfocus.org/">NumFocus</a>.</p>
-                        
-                        <p>Please remember to <a href="acknowledging">acknowledge and cite</a> the use of Econ-ARK.</p>
-                        
-                        <p>We are very grateful for any <a href="https://numfocus.salsalabs.org/donate-to-econ-ark/">donations</a> towards the Econ-ARK project.</p>                        
+                    <p>Econ-ARK is headed by <a href="http://www.econ2.jhu.edu/people/ccarroll/">Christopher D.
+                            Carroll</a>, Professor of Economics at the Johns Hopkins University.</p>
 
-                    </div>
+                    <p>The project is a recipient of grants from the <a href="https://sloan.org/">Sloan foundation</a>
+                        and the <a href="https://www.thinkforwardinitiative.com/">Think Forward Initiative</a>, and is
+                        under the umbrella of projects with fiscal sponsorship by <a
+                            href="https://www.numfocus.org/">NumFocus</a>.</p>
 
-                    <div class="offset-md-1 col-md-3">
+                    <p>Please remember to <a href="acknowledging">acknowledge and cite</a> the use of Econ-ARK.</p>
 
-                        <p class="sponsor"><a href="https://www.numfocus.org/"><img src="{{ '/assets/img/numfocus.png' | relative_url }}" alt="NumFOCUS logo" class="responsive"></a></p>
-
-                    </div>
-
-                </div>
-
-                <div class="row">
-
-                    <p>&copy; 2023 &ndash; <a href="https://econ-ark.org/">Econ-ARK</a>. Hosted with <a href="https://pages.github.com/">GitHub Pages</a>.</p>
+                    <p>We are very grateful for any <a
+                            href="https://numfocus.salsalabs.org/donate-to-econ-ark/">donations</a> towards the Econ-ARK
+                        project.</p>
 
                 </div>
 
+                <div class="offset-md-1 col-md-3">
+
+                    <p class="sponsor"><a href="https://www.numfocus.org/"><img
+                                src="{{ '/assets/img/numfocus.png' | relative_url }}" alt="NumFOCUS logo"
+                                class="responsive"></a></p>
+
+                </div>
+
             </div>
 
-        </footer>
+            <div class="row">
 
-        <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js" integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL" crossorigin="anonymous"></script>
+                <p>&copy; 2023 &ndash; <a href="https://econ-ark.org/">Econ-ARK</a>. Hosted with <a
+                        href="https://pages.github.com/">GitHub Pages</a>.</p>
 
-        <script src="https://code.jquery.com/jquery-3.5.1.min.js" integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+            </div>
 
-        <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
+        </div>
 
-        <!-- Include Choices JavaScript -->
-        <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+    </footer>
 
-        <script src="{{ '/assets/js/prism.js' | relative_url }}"></script>
-        <script src="/assets/js/main.js?v=1.0"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.2/dist/js/bootstrap.bundle.min.js"
+        integrity="sha384-C6RzsynM9kWDrMNeT87bh95OGNyZPhcTNXj1NW7RuBCsyN/o0jlpcV8Qyq46cDfL"
+        crossorigin="anonymous"></script>
 
-    </body>
+    <script src="https://code.jquery.com/jquery-3.5.1.min.js"
+        integrity="sha256-9/aliU8dGd2tb6OSsuzixeV4y/faTqgFtohetphbbj0=" crossorigin="anonymous"></script>
+
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/jquery-modal/0.9.1/jquery.modal.min.js"></script>
+
+    <!-- Include Choices JavaScript -->
+    <script src="https://cdn.jsdelivr.net/npm/choices.js/public/assets/scripts/choices.min.js"></script>
+
+    <script src="{{ '/assets/js/prism.js' | relative_url }}"></script>
+    <script src="/assets/js/main.js?v=1.0"></script>
+
+</body>
+
 </html>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -1,16 +1,46 @@
 ---
 layout: default
 ---
-<div class="hero py-5">
+<div class="hero py-2">
   <div class="container">
     <div class="row">
       <div class="col-md-5 px-5">
-          <p class="hero-logo"><a href="/"><img src="{{ '/assets/img/econ-ark-logo.png' | relative_url }}"></a></p>
+        <p class="hero-logo"><a href="/"><img src="{{ '/assets/img/econ-ark-logo.png' | relative_url }}"></a></p>
       </div>
       <div class="hero-desc col-md-7 col-offset-1 px-5">
-            <p>The primary goals of Econ-ARK are to make entry into the world of economic modeling easy; to accelerate
-              the development of this kind of modeling for policy-making and academic research; and to increase the
-              openness, replicability, and interoperability of modeling tools.</p>
+
+
+        <div class="home-hark" style="font-size:1.2rem; background-color: transparent; border-top:0;">
+          <div class="container my-5">
+            <div class="row">
+              <div class="offset-md-1 col-md-10">
+                <h2 style="display:none;"><a href="https://docs.econ-ark.org/">Welcome to Econ-ARK</a></h2>
+                <p>The heart of Econ-ARK is making reproducible papers. The <a
+                    href="https://docs.econ-ark.org/overview/ARKitecture.html">ARKitecture of Econ-ARK</a> consists of a
+                  code toolkit (HARK), demonstrations of using the toolkit (DemARK), and a <a
+                    href="/materials/">App Library</a> replicating modeling results of published papers (REMARK).
+                </p>
+                <p>Read through the <a href="https://docs.econ-ark.org/guides/quick_start.html">Quick Start Guide</a> to
+                  get up and running with HARK, or for developers the <a
+                    href="https://docs.econ-ark.org/guides/contributing.html">Contributing Guidelines</a>.</p>
+                <p>
+                  <img src="https://badgen.net/github/last-commit/econ-ark/hark">
+                  <img src="https://badgen.net/github/commits/econ-ark/hark">
+                  <img src="https://badgen.net/github/release/econ-ark/hark">
+                  <img src="https://badgen.net/github/contributors/econ-ark/hark">
+                  <img src="https://badgen.net/github/forks/econ-ark/hark">
+                </p>
+                <p class="link" style="display:none;">
+                  <a href="https://docs.econ-ark.org/">Econ-ARK Documentation</a>
+                  <a href="https://docs.econ-ark.org/example_notebooks/Gentle-Intro-To-HARK.html">A Gentle Introduction
+                    to HARK</a>
+                  <a href="https://github.com/econ-ark/HARK">HARK GitHub</a>
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
       </div>
     </div>
   </div>
@@ -18,77 +48,97 @@ layout: default
 
 <h1 class="visuallyhidden">Econ-ARK</h1>
 
-<div class="ark-parts py-5">
+<div class="home-search">
+
+  <div class="container">
+    <div class="row px-5 py-2 col-md-10 offset-md-1">
+
+
+      <div class="bd-example">
+        <label for="homeSearchInput" class="form-label form-title">Econ-ARK Materials App Library</label>
+        <div class="row">
+          <div class="col-md-10">
+            <div>
+              <input type="text" id="homeSearchInput" class="form-control" aria-describedby="searchHelpBlock">
+
+<!-- here -->
+
+            </div>
+          </div>
+          <div class="col-md-2">
+            <button type="submit" class="btn btn-primary w-100">View all</button>
+          </div>
+        </div>
+        
+        
+        <div class="demo">
+
+        </div>
+        <div id="searchHelpBlock" class="form-text hidden">
+          Search the Econ-ARK Appl library Lorem ipsum dolor sit amet consectetur, adipisicing elit. 
+        </div>
+      </div>
+
+
+
+
+    </div>
+  </div>
+
+</div>
+
+<div class="ark-parts px-5 py-5">
   <div class="container">
     <div class="row gx-5">
       <div class="part col-md-4 px-5 my-5">
-        <h2 class="title">HARK</h2>
+        <div class="title">
+          <h2 class="heading">HARK</h2>
+          <p class="resource">Toolkit</p>
+        </div>
         <p class="subtitle">Heterogeneous Agents Resources and toolKit</p>
         <div class="desc">
-          <p>HARK is a toolkit for simplifying and speeding up the development of solutions and estimation methods for
-            new
-            models.</p>
-          <p>Econ-ARK has developed an open source repository of highly modular, easily interoperable code for solving,
-            simulating, and estimating dynamic economic models with heterogeneous agents.</p>
+          <p>Econ-ARK developed a highly modular &amp; interoperable open source toolkit for
+            simulating, estimating and solving dynamic economic models with heterogeneous agents.</p>
         </div>
         <p class="link"><a href="https://docs.econ-ark.org/overview/introduction.html">Introduction to HARK</a></p>
       </div>
       <div class="part col-md-4 px-5 my-5">
-        <h2 class="title">DemARK</h2>
-        <p class="subtitle">Demonstrations of tools, AgentTypes, and ModelClasses</p>
-        <div class="desc">
-          <p>DemARK contains a collection of code demonstrations to give you a feeling for how the code works and what
-            you
-            can do with it.</p>
-          <p>These demonstrations form a repository produced by Econ-ARK containing a series of Jupyter Notebooks for
-            demonstrating how to use material in the Econ-ARK.</p>
+        <div class="title">
+          <h2 class="heading">REMARK</h2>
+          <p class="resource">App Library</p>
         </div>
-        <p class="link"><a href="https://github.com/econ-ark/DemARK">DemARK Repository</a></p>
-      </div>
-      <div class="part col-md-4 px-5 my-5">
-        <h2 class="title">REMARK</h2>
         <p class="subtitle">R[eplications/eproductions] and Explorations Made using ARK</p>
         <div class="desc">
-          <p>REMARKs are self-contained and complete projects that can be executed by anyone.</p>
-          <p>They include Explorations using HARK to demonstrate modelling ideas, Replications of important results of
-            published papers written using other tools, and Reproductions of all the code within a paper. </p>
+          <p>REMARKs are self-contained code repositories that utilize HARK to reproduce calculations from papers and
+            projects.</p>
         </div>
-        <p class="link"><a href="/materials/">Materials Library</a></p>
+        <p class="link"><a href="/materials/remark/">REMARKs</a></p>
+      </div>
+      <div class="part col-md-4 px-5 my-5">
+        <div class="title">
+          <h2 class="heading">OTHER</h2>
+          <p class="resource">Teaching</p>
+        </div>
+        <p class="subtitle">Demonstrations of tools, AgentTypes, and ModelClasses</p>
+        <div class="desc">
+          <p>View the complete collection of our tools, materials, demonstrations, tutorials, blogs, assignments,
+            documentation, and teaching.</p>
+        </div>
+        <p class="link"><a href="/materials/">DemARK</a></p>
       </div>
     </div>
   </div>
 </div>
 
-<div class="home-hark py-5 px-5">
-  <div class="container my-5">
-    <div class="row">
-      <div class="offset-md-1 col-md-10">
-        <h2><a href="https://docs.econ-ark.org/">Welcome to Econ-ARK</a></h2>
-        <p>The heart of Econ-ARK is making reproducible papers. The <a href="https://docs.econ-ark.org/overview/ARKitecture.html">ARKitecture of Econ-ARK</a> consists of a code toolkit (HARK), demonstrations of using the toolkit (DemARK), and a <a href="/materials/">Materials Library</a> replicating modeling results of published papers (REMARK).</p>
-        <p>Read through the <a href="https://docs.econ-ark.org/guides/quick_start.html">Quick Start Guide</a> to get up and running with HARK, or for developers the <a href="https://docs.econ-ark.org/guides/contributing.html">Contributing Guidelines</a>.</p>
-          <p>
-            <img src="https://badgen.net/github/last-commit/econ-ark/hark">
-            <img src="https://badgen.net/github/commits/econ-ark/hark">
-            <img src="https://badgen.net/github/release/econ-ark/hark">
-            <img src="https://badgen.net/github/contributors/econ-ark/hark">
-            <img src="https://badgen.net/github/forks/econ-ark/hark">
-          </p>
-        <p class="link">
-          <a href="https://docs.econ-ark.org/">Econ-ARK Documentation</a>
-          <a href="https://docs.econ-ark.org/example_notebooks/Gentle-Intro-To-HARK.html">A Gentle Introduction to HARK</a>
-          <a href="https://github.com/econ-ark/HARK">HARK GitHub</a>
-        </p>
-      </div>
-    </div>
-  </div>
-</div>
+
 
 <div class="home-materials py-5 px-5">
-  <div class="container mt-5">
+  <div class="container mt-5 mb-5">
     <div class="row">
       <div class="offset-md-1 col-md-10 text-center">
-        <h2><a href="/materials/">Materials Library</a></h2>
-        <p>The Materials Library is a single-source-of-truth for all Econ-ARK published and working materials. These include reproducible papers, examples, demonstrations, documentation, notebooks and teaching material.</p>
+        <h2><a href="/materials/">Materials App Library</a></h2>
+        <p>The Materials Library is a single-source-of-truth for all Econ-ARK published and working materials. These
+          include reproducible papers, examples, demonstrations, documentation, notebooks and teaching material.</p>
       </div>
     </div>
     <div class="row gx-5">
@@ -98,7 +148,9 @@ layout: default
             <li>Carroll</li>
           </ul>
           <h3 class="title"><a href="/materials/bufferstocktheory">BufferStockTheory</a></h3>
-          <p class="summary">This paper builds foundations for rigorous and intuitive understanding of 'buffer stock' saving models (Bewley (1977)-like models with a wealth target), pairing each theoretical result with quantitative illustrations. After describing...</p>
+          <p class="summary">This paper builds foundations for rigorous and intuitive understanding of 'buffer stock'
+            saving models (Bewley (1977)-like models with a wealth target), pairing each theoretical result with
+            quantitative illustrations. After describing...</p>
           <ul class="tags">
             <li>REMARK</li>
             <li>Reproduction</li>
@@ -112,7 +164,9 @@ layout: default
             <li>Carroll</li>
           </ul>
           <h3 class="title"><a href="/materials/beyond-the-streetlight">Beyond the streetlight</a></h3>
-          <p class="summary">This repository provides an analysis of the trend in forecast errors made by the Tealbook/Greenbook(GB) and the Survey of Professional Forecasters(SPF) for measures of the unemployment rate and real growth...</p>
+          <p class="summary">This repository provides an analysis of the trend in forecast errors made by the
+            Tealbook/Greenbook(GB) and the Survey of Professional Forecasters(SPF) for measures of the unemployment rate
+            and real growth...</p>
           <ul class="tags">
             <li>REMARK</li>
             <li>Notebook</li>
@@ -125,8 +179,10 @@ layout: default
             <li>Ganong</li>
             <li>Noel</li>
           </ul>
-          <h3 class="title"><a href="/materials/ganongnoelui">Consumer Spending during Unemployment: Positive and Normative Implications</a></h3>
-          <p class="summary">Analysis of Models for "Consumer Spending During Unemployment- Positive and Normative Implications"</p>
+          <h3 class="title"><a href="/materials/ganongnoelui">Consumer Spending during Unemployment: Positive and
+              Normative Implications</a></h3>
+          <p class="summary">Analysis of Models for "Consumer Spending During Unemployment- Positive and Normative
+            Implications"</p>
           <ul class="tags">
             <li>REMARK</li>
             <li>Replication</li>
@@ -136,7 +192,7 @@ layout: default
     </div>
     <div class="row pt-5">
       <div class="offset-md-1 col-md-10 text-center">
-        <p class="link"><a href="/materials/">View all Materials</a></p>
+        <p class="link"><a href="/materials/">View all Apps</a></p>
       </div>
     </div>
   </div>

--- a/assets/sass/_main.scss
+++ b/assets/sass/_main.scss
@@ -9,6 +9,7 @@ body {
   background-color: #f7fafb;
   color: #444;
   font-size: 1rem;
+  background-color: $ark-footer;
 }
 
 em,
@@ -53,18 +54,26 @@ pre {
 a,
 a:link,
 body a {
-  color: $ark-blue;
+  color: $ark-darkblue;
   transition: all 0.2s linear;
   text-decoration: none;
   font-weight: 500;
-  border-bottom: 2px solid $ark-blue;
+  border-bottom: 2px solid $ark-darkblue;
   padding-bottom: 0.1rem;
 }
 
 a:hover {
-  color: $ark-blue;
-  border-color: $ark-blue;
+  color: $ark-darkblue;
+  border-color: $ark-darkblue;
   text-decoration: none;
+}
+
+.btn {
+  background-color: $ark-darkblue;
+  &:hover {
+    background-color: $ark-blue;
+    border-color: $ark-blue;
+  }
 }
 
 .link {
@@ -72,13 +81,14 @@ a:hover {
   a {
     display: inline-block;
     color: inherit;
-    color: $ark-blue;
+    color: $ark-darkblue;
     text-decoration: none;
-    border: 2px solid $ark-blue;
+    border: 2px solid $ark-darkblue;
     padding: 0.25rem 0.5rem;
 
     &:hover {
       background-color: $ark-blue;
+      border-color: $ark-blue;
       color: #fff !important;
     }
   }
@@ -87,13 +97,13 @@ a:hover {
 a.button {
   display: inline-block;
   color: inherit;
-  color: $ark-lightblue;
+  color: $ark-blue;
   text-decoration: none;
-  border: 2px solid $ark-lightblue;
+  border: 2px solid $ark-blue;
   padding: 0.25rem 0.5rem;
 
   &:hover {
-    background-color: $ark-lightblue;
+    background-color: $ark-blue;
     color: #fff !important;
   }
 }
@@ -103,7 +113,7 @@ a.button {
 }
 
 .header {
-  background: $ark-blue;
+  background: $ark-darkblue;
   color: #fff;
   padding: 0.5rem 0;
   margin: 0 0 4rem 0;
@@ -118,6 +128,7 @@ a.button {
     margin: 0;
 
     a {
+      text-decoration: none;
       img {
         width: 150px;
       }
@@ -178,17 +189,17 @@ a.button {
     ul {
       li {
         a {
-          color: $ark-blue;
+          color: $ark-darkblue;
           border-bottom: 2px solid transparent;
 
           &:hover {
-            border-bottom: 2px solid $ark-blue;
+            border-bottom: 2px solid $ark-darkblue;
           }
         }
 
         &.active {
           a {
-            border-bottom: 2px solid $ark-blue;
+            border-bottom: 2px solid $ark-darkblue;
           }
         }
       }
@@ -213,6 +224,8 @@ a.button {
     display: flex;
     align-items: center;
   }
+
+
 }
 
 .ark-parts {
@@ -224,15 +237,29 @@ a.button {
 
     .part {
       font-size: 1.2rem;
-      border-color: $ark-lightblue;
-      color: $ark-lightblue;
+      border-color: $ark-pink;
+      color: $ark-pink;
 
       .title {
+        display: flex;
+        flex-direction: row;
+        justify-content: space-between;
+        align-items: flex-end;
         padding: 0 0 0.25rem 0;
         border-bottom-width: 2px;
         border-bottom-style: solid;
         border-color: inherit;
         margin: 0;
+        .heading {
+          margin:0;
+          padding:0;
+          line-height: 1;
+        }
+        .resource {
+          margin: 0;
+          padding:0;
+          text-transform: uppercase;
+        }
       }
 
       .subtitle {
@@ -244,35 +271,35 @@ a.button {
       }
 
       .desc {
-        padding: 1.5rem 0;
+        padding: 0 0;
         color: #898989;
       }
 
       .link {
         a {
           color: inherit;
-          color: $ark-lightblue;
+          color: $ark-pink;
           text-decoration: none;
-          border: 2px solid $ark-lightblue;
+          border: 2px solid $ark-pink;
           padding: 0.25rem 0.5rem;
 
           &:hover {
-            background-color: $ark-lightblue;
+            background-color: $ark-pink;
             color: #fff !important;
           }
         }
       }
 
       &:nth-child(2) {
-        border-color: $ark-pink;
-        color: $ark-pink;
+        border-color: $ark-blue;
+        color: $ark-blue;
 
         .link a {
-          color: $ark-pink;
-          border-color: $ark-pink;
+          color: $ark-blue;
+          border-color: $ark-blue;
 
           &:hover {
-            background-color: $ark-pink;
+            background-color: $ark-blue;
           }
         }
       }
@@ -300,9 +327,12 @@ a.button {
   background-color: #fff;
 
   a {
-    //color: $ark-blue;
-    color: $ark-lightblue;
-    border-color: $ark-lightblue;
+    color: $ark-blue;
+    border-color: $ark-blue;
+    &:hover {
+      color: $ark-darkblue;
+      border-color: $ark-darkblue;
+    }
   }
 
   .link {
@@ -310,23 +340,35 @@ a.button {
 
     a {
       margin-top: 1rem;
-      color: $ark-lightblue;
-      border-color: $ark-lightblue;
+      color: $ark-blue;
+      border-color: $ark-blue;
 
       &:hover {
-        background-color: $ark-lightblue;
+        background-color: $ark-blue;
       }
     }
   }
 }
 
+.home-search {
+  .form-label {
+    font-size: 1.5rem;
+  }
+
+}
+
 .home-materials {
+  background-color: #ffffff;
   border-top: 1px solid #999;
   font-size: 1.2rem;
 
-  h2 a {
-    //color: $ark-lightblue;
-    //border-color: $ark-lightblue;
+  h2 {
+    a {
+      &:hover {
+        color: $ark-blue;
+        border-color: $ark-blue;
+      }
+    }
   }
 
   .link {
@@ -335,10 +377,17 @@ a.button {
 }
 
 .footer {
-  padding: 5rem 0 4.5rem 0;
-  background-color: #1f476b0f;
-  margin: 4rem 0 0 0;
-  border-top: 1px solid $ark-blue;
+  padding: 6rem 0 4.5rem 0;
+  background-color: $ark-footer;
+  //margin: 4rem 0 0 0;
+  border-top: 1px solid $ark-grey;
+  a {
+    &:hover {
+      color: $ark-blue;
+      border-color: $ark-blue;
+      transition: all 0.2s linear;
+    }
+  }
 
   .sponsor {
     a {
@@ -459,10 +508,13 @@ a.button {
     line-height: 1.5;
     a {
       text-decoration: none;
-      color: $ark-blue;
+      color: $ark-darkblue;
+      border-color: $ark-darkblue;
 
       &:hover {
         //text-decoration: underline;
+        color: $ark-blue;
+        border-color: $ark-blue;
       }
     }
 
@@ -540,12 +592,16 @@ a.button {
       //min-width: 100px;
       text-align: center;
       line-height: 1;
-      background: $ark-blue;
+      background: $ark-darkblue;
       //background-color: #e2eef1;
       border-radius: 5px;
       font-weight: 500;
       color: #fff;
       cursor: pointer;
+      &:hover {
+        background-color: $ark-blue;
+        transition: all 0.2s linear;
+      }
     }
 
     @media (max-width: 1023px) {
@@ -1009,7 +1065,7 @@ a.button {
   left: 0;
   width: 100vw;
   height: 100vh;
-  background-color: #1f476be6;
+  background-color: $ark-darkblue;
   animation: fadeIn 0.5s;
 
   &.show {
@@ -1320,3 +1376,34 @@ a.button {
     page-break-after: avoid;
   }
 }
+
+
+
+
+
+.bd-example {
+  font-size: 1.2rem;
+  padding: 1.5rem;
+  margin-right: 0;
+  margin-left: 0;
+  border-width: 1px;
+  border-top-left-radius: .25rem;
+  border-top-right-radius: .25rem;
+  margin: 1rem -.75rem 0;
+  border: 2px solid $ark-darkblue;
+  background: #fff;
+  //box-shadow: rgba(0, 0, 0, 0.1) 0px 20px 25px -5px, rgba(0, 0, 0, 0.04) 0px 10px 10px -5px;
+  box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 1px, rgba(0, 0, 0, 0.07) 0px 2px 2px, rgba(0, 0, 0, 0.07) 0px 4px 4px, rgba(0, 0, 0, 0.07) 0px 8px 8px, rgba(0, 0, 0, 0.07) 0px 16px 16px;
+  //box-shadow: rgba(17, 17, 26, 0.05) 0px 4px 16px, rgba(17, 17, 26, 0.05) 0px 8px 32px;
+
+  //border-left: 0.25rem #FCB040 solid;
+  border-radius: 10px;
+  .form-title {
+    color: $ark-darkblue;
+  }
+
+}
+
+
+
+

--- a/assets/sass/_variables.scss
+++ b/assets/sass/_variables.scss
@@ -284,13 +284,15 @@ textarea {
  **/
 
 // Colours
-// $ark-blue: #3E8ACC;
-$ark-blue: #1f476b;
-$ark-lightblue: #00aeef;
+$ark-blue: #00aeef;
 $ark-pink: #ed217c;
 $ark-green: #39b54a;
 $ark-yellow: #fcb040;
+
+$ark-navy: #3E8ACC;
+$ark-darkblue: #1f476b;
 $ark-grey: #676470;
+$ark-footer: #E9EFF2;
 
 // Fonts
 $font: 'Roboto', sans-serif;


### PR DESCRIPTION
Working towards an immediate access to any 'self runing' REMARK or other app through the Econ-ARK **Materials App Library**.

The screenshot below demonstrates current work to date, including updated website structure: HARK, REMARK, OTHER and has clear delineations of each section's contents ie. HARK: Toolkit, REMARK: App Library, OTHERS: Teaching.

The "Econ-ARK Materials App Library" is a new feature giving all users immediate access to a rersource they might need by taking advantage of Cameron's page content searchable functionality.

Ideally as a user begins to type, we will reveal an immediate list matching resources closest to your matching input. 

This search functionality should provide immediate results as the user types each new character the list below (say max 5, with 'view all'). From each visible results we can potentially present 'view author', 'edit metadata', and 'launch binder' or even our custom servers when needing to.

This improves UX so that a user can potentially type from the homepage and click just once to access a multiple of functionality including load a binder or etc. We will also retain the click through resource page with all metadata.

![image](https://github.com/econ-ark/econ-ark.org/assets/5886045/125c1b3a-44b3-4462-a4ed-c6c94ac65f27)
