### PR TITLE
Fixing doc links

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -30,7 +30,7 @@ layout: default
         <div class="desc">
           <p>Econ-ARK developed a highly modular & interoperable open source toolkit for simulating, estimating and solving dynamic economic models with heterogeneous agents</p>
         </div>
-        <p class="link"><a href="https://docs.econ-ark.org/overview/introduction.html">Introduction to HARK</a></p>
+        <p class="link"><a href="https://docs.econ-ark.org/Documentation/overview/introduction.html">Introduction to HARK</a></p>
       </div>
 
       <div class="part col-md-4 px-5 my-5">
@@ -66,8 +66,8 @@ layout: default
     <div class="row">
       <div class="offset-md-1 col-md-10">
         <h2><a href="https://docs.econ-ark.org/">Welcome to Econ-ARK</a></h2>
-        <p>The heart of Econ-ARK is making reproducible papers. The <a href="https://docs.econ-ark.org/overview/ARKitecture.html">ARKitecture of Econ-ARK</a> consists of a code toolkit (HARK), demonstrations of using the toolkit (DemARK), and a <a href="/materials/">Materials Library</a> replicating modeling results of published papers (REMARK).</p>
-        <p>Read through the <a href="https://docs.econ-ark.org/guides/quick_start.html">Quick Start Guide</a> to get up and running with HARK, or for developers the <a href="https://docs.econ-ark.org/guides/contributing.html">Contributing Guidelines</a>.</p>
+        <p>The heart of Econ-ARK is making reproducible papers. The <a href="https://docs.econ-ark.org/Documentation/overview/ARKitecture.html">ARKitecture of Econ-ARK</a> consists of a code toolkit (HARK), demonstrations of using the toolkit (DemARK), and a <a href="/materials/">Materials Library</a> replicating modeling results of published papers (REMARK).</p>
+        <p>Read through the <a href="https://docs.econ-ark.org/Documentation/guides/quick_start.html">Quick Start Guide</a> to get up and running with HARK, or for developers the <a href="https://docs.econ-ark.org/Documetation/guides/contributing.html">Contributing Guidelines</a>.</p>
           <p>
             <img src="https://badgen.net/github/last-commit/econ-ark/hark">
             <img src="https://badgen.net/github/commits/econ-ark/hark">
@@ -77,7 +77,7 @@ layout: default
           </p>
         <p class="link">
           <a href="https://docs.econ-ark.org/">Econ-ARK Documentation</a>
-          <a href="https://docs.econ-ark.org/example_notebooks/Gentle-Intro-To-HARK.html">A Gentle Introduction to HARK</a>
+          <a href="https://docs.econ-ark.org/examples/Gentle-Intro/Gentle-Intro-To-HARK.html">A Gentle Introduction to HARK</a>
           <a href="https://github.com/econ-ark/HARK">HARK GitHub</a>
         </p>
       </div>

--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -67,7 +67,7 @@ layout: default
       <div class="offset-md-1 col-md-10">
         <h2><a href="https://docs.econ-ark.org/">Welcome to Econ-ARK</a></h2>
         <p>The heart of Econ-ARK is making reproducible papers. The <a href="https://docs.econ-ark.org/Documentation/overview/ARKitecture.html">ARKitecture of Econ-ARK</a> consists of a code toolkit (HARK), demonstrations of using the toolkit (DemARK), and a <a href="/materials/">Materials Library</a> replicating modeling results of published papers (REMARK).</p>
-        <p>Read through the <a href="https://docs.econ-ark.org/Documentation/guides/quick_start.html">Quick Start Guide</a> to get up and running with HARK, or for developers the <a href="https://docs.econ-ark.org/Documetation/guides/contributing.html">Contributing Guidelines</a>.</p>
+        <p>Read through the <a href="https://docs.econ-ark.org/Documentation/guides/quick_start.html">Quick Start Guide</a> to get up and running with HARK, or for developers the <a href="https://docs.econ-ark.org/Documentation/guides/contributing.html">Contributing Guidelines</a>.</p>
           <p>
             <img src="https://badgen.net/github/last-commit/econ-ark/hark">
             <img src="https://badgen.net/github/commits/econ-ark/hark">


### PR DESCRIPTION
This fixes the broken doc links that were created when Symlinks were removed from the HARK documentation.