### PR TITLE
EconARK landing page link and button updates

### DIFF
--- a/_layouts/home.html
+++ b/_layouts/home.html
@@ -40,9 +40,9 @@ layout: default
         </div>
         <p class="subtitle">R[eplications/eproductions] and Explorations Made using ARK</p>
         <div class="desc">
-            <p>A <a href="https://github.com/econ-ark/REMARK">REMARK</a> is an executable archive that reproduces its own results on any computer using <a href="https://en.wikipedia.org/wiki/Docker_software">docker</a></p>
+            <p>A REMARK is an executable archive that reproduces its own results on any computer</p>
         </div>
-        <p class="link"><a href="/materials/">REMARKs</a></p>
+        <p class="link"><a href="/materials/?select=REMARK">REMARKs</a></p>
       </div>
 
       <div class="part col-md-4 px-5 my-5">
@@ -54,7 +54,7 @@ layout: default
         <div class="desc">
           <p>View the complete collection of our tools, materials, demonstrations, tutorials, blogs, assignments, documentation, and teaching</p>
         </div>
-        <p class="link"><a href="https://github.com/econ-ark/DemARK">DemARK</a></p>
+        <p class="link"><a href="/materials/?select=DemARK">DemARK</a></p>
       </div>
 
     </div>

--- a/_layouts/materials.html
+++ b/_layouts/materials.html
@@ -166,6 +166,47 @@ layout: default
       li.addEventListener('click', addTagToFilter);
     });
 
+
+    // Get the already initialized Choices.js instance
+    //const selectElement = document.getElementById('mySelect');
+    //const choicesInstance = choices;
+
+    // Function to get the value from query string or anchor hash
+    function getSelectionFromUrl() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const hash = window.location.hash.substring(1);
+
+        // Check for query string parameter 'select' first
+        if (urlParams.has('select')) {
+            return urlParams.get('select');
+        }
+        // If not found, check for hash value
+        else if (hash) {
+            return hash;
+        }
+        return null;
+    }
+
+    // Auto-select the option based on the URL
+    function autoSelectOption() {
+        const selection = getSelectionFromUrl();
+        if (selection) {
+            const option = choices.setChoiceByValue(selection);
+
+            let evt = document.createEvent("Event");
+            evt.initEvent("change", true, true);
+            tagSelect.dispatchEvent(evt);
+
+            // Check if the option exists
+            if (!option) {
+                console.warn(`Option with value "${selection}" not found.`);
+            }
+        }
+    }
+
+    // Call the autoSelectOption function on page load
+    autoSelectOption();
+
   });
 
 </script>


### PR DESCRIPTION
This PR includes:

1) You can now create specific URLs to open the materials page with a tag selected, in two formats.
(eg. **https://econ-ark.org/materials/#DemARK**  or  **https://econ-ark.org/materials/?select=Notebook**)

2) Updated the REMARK and DemARK buttons to link to the material page showing only respective materials.

3) ...