### PR TITLE
Case insensitive redirect

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -41,3 +41,9 @@ defaults:
       type: 'team'
     values:
       order: 99
+
+plugins:
+  - jekyll-redirect-from
+
+whitelist:
+  - jekyll-redirect-from

--- a/scripts/populate_materials.py
+++ b/scripts/populate_materials.py
@@ -1,10 +1,10 @@
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from io import StringIO
 from subprocess import run
 from tempfile import TemporaryDirectory
-from pathlib import Path
-from time import sleep
+
 from yaml import safe_load, dump as yaml_dump
-from concurrent.futures import ThreadPoolExecutor, as_completed
-from io import StringIO
 
 def parse_yaml_header(f):
     metadata = StringIO()


### PR DESCRIPTION
Adds case-insensitive redirects to each REMARK.

This uses [Jekyll Redirect From](https://github.com/jekyll/jekyll-redirect-from) and adds the redirects to
the metadata of each page before jekyll builds the site.

@DrDrij would this be useful to add for all materials pages? I can extend it so that it doesn't only work with REMARKs.