### PR TITLE
fix stale filename in GH Action

### DIFF
--- a/.github/workflows/site-preprocess.yml
+++ b/.github/workflows/site-preprocess.yml
@@ -23,7 +23,7 @@ jobs:
           python -m pip install --upgrade pip
           python -m pip install pyyaml==6.0.0
       - name: copy REMARK metadata
-        run: python scripts/populate_materials.py
+        run: python scripts/populate_remarks.py
       - name: case insensitive redirects
         run: python scripts/caseinsensitive_redirects.py
       - name: update gh-pages branch


### PR DESCRIPTION
@DrDrij the merging of #79 had one unexpected bug from a old file name in the GitHub Action to deploy the website. This PR fixes that typo and I have confirmed a successful run the the GH Action on my end.