### PR TITLE
Fix NameError when REMARK.md is missing

### DIFF
--- a/scripts/populate_remarks.py
+++ b/scripts/populate_remarks.py
@@ -52,12 +52,15 @@ if __name__ == '__main__':
             with open(cff) as f:
                 remark_data = safe_load(f)
 
+            body = ''  # Default to empty body
             remark_md = repo_path / 'REMARK.md'
             if remark_md.exists():
                 with open(remark_md) as f:
                     mdata, f = parse_yaml_header(f)
                     body = f.read()
                     remark_data.update(mdata)
+            else:
+                print(f"WARNING: {name} has CITATION.cff but no REMARK.md file")
 
             with open(repo_root / '_materials' / f'{name}.md', 'w') as f:
                 f.write('---\n')


### PR DESCRIPTION
- Initialize body variable to empty string before checking for REMARK.md
- Add warning message when repository has CITATION.cff but no REMARK.md
- Prevents build failure while maintaining visibility of missing files

This fixes the fatal NameError that occurred when processing repositories like SequentialEGM that have CITATION.cff but no REMARK.md file.

🤖 Generated with [Claude Code](https://claude.ai/code)