### PR TITLE
Revert Jekyll 4 changes for GitHub Pages compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,18 +1,7 @@
 source 'https://rubygems.org'
 
-# Jekyll core
-gem 'jekyll', '~> 4.3.0'
-
-# Theme and styling
-gem 'minima', '~> 2.5'
-
-# Development dependencies
-group :jekyll_plugins do
-  gem 'jekyll-seo-tag', '~> 2.8'      # Automatic SEO meta tags
-  gem 'jekyll-sitemap', '~> 1.4'      # XML sitemap generation  
-  gem 'jekyll-feed', '~> 0.17'        # RSS/Atom feed generation
-  gem 'jekyll-redirect-from', '~> 0.16'  # URL redirection
-end
+# GitHub Pages compatibility
+gem 'github-pages', group: :jekyll_plugins
 
 # Windows and JRuby compatibility
 platforms :mingw, :x64_mingw, :mswin, :jruby do
@@ -25,8 +14,6 @@ gem 'wdm', '~> 0.1.1', :platforms => [:mingw, :x64_mingw, :mswin]
 
 # Lock JRuby to 2.5 branch
 gem 'http_parser.rb', '~> 0.6.0', :platforms => [:jruby]
-
-# gem 'github-pages', group: :jekyll_plugins # Removed - incompatible with Jekyll 4.x, site uses GitHub Actions not GitHub Pages Jekyll
 
 gem 'webrick' # needed to build locally
 

--- a/assets/main.scss
+++ b/assets/main.scss
@@ -1,7 +1,7 @@
 ---
 ---
-@import "sass/variables";
-@import "sass/main";
-@import "sass/material";
-@import "sass/sections";
-@import "sass/prism";
+@import "variables";
+@import "main";
+@import "material";
+@import "sections";
+@import "prism";


### PR DESCRIPTION
- Revert Gemfile to use github-pages gem instead of Jekyll 4.3.0
- Revert SCSS import paths from 'sass/variables' back to 'variables'
- This fixes the GitHub Pages build failures caused by Jekyll version mismatch

The site was upgraded to Jekyll 4 for local development, but GitHub Pages only supports Jekyll 3.x. This commit ensures compatibility with GitHub Pages.

🤖 Generated with [Claude Code](https://claude.ai/code)