### PR TITLE
Fix journey cards to maintain horizontal layout on mobile

### DIFF
--- a/assets/sass/_sections.scss
+++ b/assets/sass/_sections.scss
@@ -124,41 +124,43 @@ $journey-contrib:  #2e7d32;  /* dev green */
   }
   
   .journey-card { 
-    flex-direction: column; 
+    flex-direction: row; /* Keep horizontal layout */
+    min-height: 140px;
   }
   
   .journey-card img { 
-    width: 100%; 
-    height: 180px;
-    object-position: center top;
+    width: 35%; /* Smaller image on mobile */
+    height: auto;
+    min-height: 100%;
+    object-position: center center;
   }
   
   .journey-content { 
-    text-align: center;
-    padding: 1.5rem 1.25rem;
+    text-align: left;
+    padding: 1.25rem 1rem;
   }
   
-  .journey-content .journey-header {
-    font-size: 1.5rem;
+  .journey-content header {
+    font-size: 1.25rem;
     margin-bottom: 0.25rem;
   }
   
   .journey-content h3 {
-    font-size: 1.1rem;
-    margin: 0.25rem 0 0.75rem;
+    font-size: 1rem;
+    margin: 0.25rem 0 0.5rem;
   }
   
   .journey-content p {
-    font-size: 0.9rem;
-    margin-bottom: 1.25rem;
-    line-height: 1.5;
+    font-size: 0.85rem;
+    margin-bottom: 1rem;
+    line-height: 1.4;
   }
   
   .journey-content .btn {
-    padding: 0.6rem 1.25rem;
-    font-size: 0.95rem;
+    padding: 0.4rem 0.8rem;
+    font-size: 0.85rem;
     width: auto;
-    min-width: 140px;
+    min-width: 100px;
   }
 }
 
@@ -169,10 +171,22 @@ $journey-contrib:  #2e7d32;  /* dev green */
   }
   
   .journey-content {
-    padding: 1.25rem 1rem;
+    padding: 1rem 0.75rem;
   }
   
   .journey-card img {
-    height: 160px;
+    width: 30%; /* Even smaller on very small screens */
+  }
+  
+  .journey-content header {
+    font-size: 1.1rem;
+  }
+  
+  .journey-content h3 {
+    font-size: 0.95rem;
+  }
+  
+  .journey-content p {
+    font-size: 0.8rem;
   }
 } 


### PR DESCRIPTION
- Keep side-by-side image/text layout on mobile devices
- Reduce image width to 35% on mobile (30% on small phones)
- Adjust font sizes and padding for compact mobile display
- Maintain readability while preventing full-width images

This ensures journey cards look good on iPhone without images dominating the screen.

🤖 Generated with [Claude Code](https://claude.ai/code)